### PR TITLE
any_value

### DIFF
--- a/test_xdb/models/under_test/any_value_test.sql
+++ b/test_xdb/models/under_test/any_value_test.sql
@@ -1,0 +1,13 @@
+WITH
+values_of_things AS (
+	SELECT 1 AS value_col
+	UNION ALL 
+	SELECT 3 AS value_col
+	UNION ALL 
+	SELECT 5 AS value_col
+)
+
+SELECT 
+    {{xdb.any_value(value_col)}} AS value_col
+FROM
+    values_of_things

--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -14,3 +14,9 @@ models:
               - accepted_values:
                   values: ['https://www.banana.com/landing-page/subpage?query=thing']
                   
+    - name: any_value_test
+      description: "tests returns any value"
+      columns:
+          - name: value_col
+            tests:
+              - not_null

--- a/xdb/macros/any_value.sql
+++ b/xdb/macros/any_value.sql
@@ -1,0 +1,10 @@
+{%- macro any_value(val) -%}
+    {%- if target.type in ('postgres','redshift',) -%} 
+	max('{{val}}') 
+    {%- elif target.type in ('snowflake','bigquery',) -%}
+        any_value('{{val}}')
+    {%- else -%}
+	{{exceptions.raise_compiler_error("macro does not support any_value for target " ~ target.type ~ ".")}}
+    {%- endif -%}
+{%- endmacro -%}
+


### PR DESCRIPTION
## Why? 
any_value alows for the first cheap value of a column

## what changed
added support for pg, bq and sf. uses MAX when any_value isn't supported. 