### PR TITLE
Adds a very simple USING macro

### DIFF
--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -20,3 +20,12 @@ models:
           - name: value_col
             tests:
               - not_null
+
+    - name: using_test
+      description: "tests using join clause"
+      columns:
+          - name: number_of_rows
+            tests:
+              - accepted_values:
+                   values: [1]
+                   quote: false

--- a/test_xdb/models/under_test/using_test.sql
+++ b/test_xdb/models/under_test/using_test.sql
@@ -1,0 +1,31 @@
+WITH
+first_cte AS (
+	SELECT 
+        1 AS id
+        , 'banana' AS fruit
+        , 'sock' AS clothing
+
+),
+second_cte AS (
+    SELECT
+        1 AS id
+        , 'banana' AS fruit
+        , 'kaboom' AS batman_sound
+        , 'bubbles' AS another_thing
+    UNION ALL
+    SELECT
+        2 AS id
+        , 'orange' AS fruit
+        , 'kaboom' AS batman_sound
+        , 'bubbles' AS another_thing
+)
+
+SELECT 
+    count(*) AS number_of_rows
+FROM
+{{xdb.using('first_cte',
+            'second_cte',
+            'fruit')}}
+WHERE
+clothing = 'sock'
+

--- a/xdb/macros/using.sql
+++ b/xdb/macros/using.sql
@@ -1,0 +1,8 @@
+{%- macro using(rel_1,rel_2,col) -%}
+    {%- if target.type in ('postgres','redshift','bigquery','snowflake',) -%} 
+	    {{rel_1}} JOIN {{rel_2}} USING ({{col}})
+    {%- else -%}
+	{{exceptions.raise_compiler_error("macro does not support any_value for target " ~ target.type ~ ".")}}
+    {%- endif -%}
+{%- endmacro -%}
+


### PR DESCRIPTION
Supports `using(relation_1, relation_2, column_name)` as a simple alias for 

```
relation_1 
JOIN
relation_2 
ON 
relation_1.column_name = relation_2.column_name
```