### PR TITLE
Creates autodocs from comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_modules/
 logs/
+__pycache__

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ _Cross-database support for dbt_
 
 This package is designed to make your sql purely portable in the DRYest possible way. 
 
+**Check out the available macros [here](docs/macros.md)**
+
+
 ### Installing xdb
 
 in your `packages.yml` add this line:

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -1,0 +1,55 @@
+
+# XDB Available Macros
+
+These macros carry functionality across **Snowflake**, **Postgresql**, **Redshift** and **BigQuery** unless otherwise noted. 
+
+
+### [using](/dbt-xdb/macros/using.sql)
+**xdb.using** (**rel_1** _None_, **rel_2** _None_, **col** _None_)
+
+
+
+
+**Returns**: 
+### [regex_string_escape](/dbt-xdb/macros/regexp.sql)
+**xdb.regex_string_escape** (**string** _None_)
+
+
+
+
+**Returns**: 
+### [regexp](/dbt-xdb/macros/regexp.sql)
+**xdb.regexp** (**val** _None_, **pattern** _None_, **flag** _None_)
+
+
+
+
+**Returns**: 
+### [datediff](/dbt-xdb/macros/datediff.sql)
+**xdb.datediff** (**part** _string_, **left_val** _date/timestamp_, **right_val** _date/timestamp_, **date_format** _pattern_)
+
+determines the delta (in `part` units) between first_val and second_val.
+       *Note* the order of left_val, right_val is reversed from Snowflake.
+
+- part one of 'day', 'week', 'month', 'year'
+- left_val the value before the minus in the equation "left - right"
+- right_val the value after the minus in the equation "left - right"
+- date_format a string pattern for the provided arguments (primarily for BigQuery)
+
+**Returns**:         An integer representing the delta in `part` units
+    
+
+### [any_value](/dbt-xdb/macros/any_value.sql)
+**xdb.any_value** (**val** _None_)
+
+
+
+
+**Returns**: 
+### [aggregate_strings](/dbt-xdb/macros/aggregate_strings.sql)
+**xdb.aggregate_strings** (**val** _None_, **delim** _None_)
+
+
+
+
+**Returns**: 

--- a/test_xdb/scripts/macrodocs.py
+++ b/test_xdb/scripts/macrodocs.py
@@ -1,0 +1,87 @@
+import re
+import os
+import sys
+
+
+def macrodocs(macros_folder, docs_file, header_text, prefix=None):
+    prefix = prefix + '.' if prefix else ''
+    print('building docs...')
+    macros = []
+    macro_start = re.compile(r'{%(-)?\s+macro .+\s+(-)?%}')
+    comments_start = re.compile(r'^\s*{#.*')
+    comments_end = re.compile(r'.*#}')
+    args_start = re.compile(r'(?i)^\s*ARGS:\s*$')
+    return_start = re.compile(r'(?i)^\s*RETURNS:')
+    macro_end = re.compile(r'{%(-)?\s+endmacro\s+(-)?%}')
+    for root, dirs, files in os.walk(macros_folder):
+        for name in filter(lambda x: x.endswith('.sql'), files):
+            print(f'Found macro {os.path.join(root,name)}.')
+            with open(os.path.join(root,name)) as f:
+                in_macro=False
+                macro=list()
+                for line in f.readlines():
+                    in_macro = True if re.match(macro_start,line) else in_macro
+                    if in_macro:
+                        macro.append(line)
+                    if re.match(macro_end,line):
+                        in_macro=False
+                        macros.append((macro,os.path.join(root,name),))
+                        macro=list()
+        
+    if len(macros) > 0:
+        with open(docs_file,'w') as f:
+            f.write(header_text)
+
+    for macro, filepath in macros:
+        declaration=macro[0][macro[0].index('{%')+2:macro[0].index('%}')].replace('-','').replace('macro','').strip()
+        dec_name = declaration[:declaration.index('(')]
+        dec_args = declaration.replace(dec_name,'').replace(')','').replace('(','').replace(' ','').split(',')
+        dec_args = map(lambda x : x.split('=')[0], dec_args)
+        description,returns = '',''
+        args=list()    
+        arg_types = dict()
+        in_docs,in_description,in_args,in_return= False,False,False,False
+        for line in macro[1:-1]:
+            if re.match(comments_start,line):
+                in_docs, in_description = True,True
+
+            if re.match(return_start,line):
+                in_return,in_args,in_description = True,False,False
+            if re.match(args_start,line):
+                in_return,in_args,in_description = False,True,False
+               
+
+            if in_description:
+                description += line.replace('{#','').replace('#}','')
+
+            if in_args:
+                if 'ARGS:' not in line.upper():
+                    types=line[line.index('(')+1 : line.index(')')]
+                    key=line[line.index('-')+1:line.index('(')].strip()
+                    arg_types[key]=types
+                    args.append(line)
+            
+            if in_return:
+                returns += line.replace('RETURNS:','').replace('returns:','').replace('{#','').replace('#}','')
+
+            if re.match(comments_end,line):
+                break
+
+        with open(docs_file,'a') as md:
+            md.write(f'\n### [{dec_name}]({filepath})')
+            md.write(f'\n**{prefix + dec_name}** (')
+            arg_string =''
+            for arg in dec_args:
+                arg_string +=f'**{arg}** _{arg_types.get(arg)}_, '
+            md.write(f'{arg_string[:-2]})\n')    
+            md.write('\n'+description.strip() +'\n')
+            for arg in args:
+                name = arg[arg.index('- ')+1 : arg.index('(')].strip()
+                desc = arg[arg.index(')')+1:].strip()
+                md.write(f'\n- {name} {desc}')
+            md.write(f'\n\n**Returns**: {returns}')
+    print('docs built.')
+            
+            
+if __name__ == '__main__':
+    macrodocs(*sys.argv[1:])

--- a/test_xdb/scripts/test_run.py
+++ b/test_xdb/scripts/test_run.py
@@ -1,14 +1,30 @@
 import yaml
 import subprocess
+import re
+import os
+from macrodocs import macrodocs
 
 
 ## run tests
 with open('./profiles.yml','r') as f:
     profile = yaml.safe_load(f.read())
-    
+success = 0
 for target in profile['default']['outputs']:
     print(f"\n\n~~~~~~~~~~~~~~~~~~ {target} ~~~~~~~~~~~~~~~~~~\n\n")
-    subprocess.call(['dbt','deps'])
-    subprocess.call(['dbt','run', '--profiles-dir','.','--target', target])
-    subprocess.call(['dbt','test', '--profiles-dir','.','--target', target])
-    
+    success += subprocess.call(['dbt','deps'])
+    success += subprocess.call(['dbt','run', '--profiles-dir','.','--target', target])
+    success += subprocess.call(['dbt','test', '--profiles-dir','.','--target', target])
+
+
+## build the docs once everything passes
+if success < 1:
+    header = """
+# XDB Available Macros
+
+These macros carry functionality across **Snowflake**, **Postgresql**, **Redshift** and **BigQuery** unless otherwise noted. 
+
+"""
+    macrodocs('/dbt-xdb/macros',
+              '/dbt-xdb/docs/macros.md',
+              header,
+              'xdb')


### PR DESCRIPTION
## Why? 
this is pretty far off the reservation and I apologize. but it was driving me nuts that we have zero automated documentation here and I feel like it was worth the slight trip off the beaten path.

This helper script builds a markdown macros.md index from jinja docstrings. This lets us write normal docstrings in the macros and have clean docs - which I feel like we really need if people will be using this as a utility class. 

## What changes? 
I added the docs build into the test suite so every test run also builds the docs. That may not be the most appropriate place for this really. but I'm experimenting here. 

check out the docs generated at `/docs/macros.md`, and the docstrings that make them in the `datediff` macro. 