### PR TITLE
adds "quarter" support to DATEDIFF

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -31,7 +31,7 @@ These macros carry functionality across **Snowflake**, **Postgresql**, **Redshif
 determines the delta (in `part` units) between first_val and second_val.
        *Note* the order of left_val, right_val is reversed from Snowflake.
 
-- part one of 'day', 'week', 'month', 'year'
+- part one of 'day', 'week', 'month', 'year', 'quarter'
 - left_val the value before the minus in the equation "left - right"
 - right_val the value after the minus in the equation "left - right"
 - date_format a string pattern for the provided arguments (primarily for BigQuery)

--- a/macros/datediff.sql
+++ b/macros/datediff.sql
@@ -2,20 +2,24 @@
     {# determines the delta (in `part` units) between first_val and second_val.
        *Note* the order of left_val, right_val is reversed from Snowflake.
        ARGS:
-         - part (string) one of 'day', 'week', 'month', 'year'
+         - part (string) one of 'day', 'week', 'month', 'year', 'quarter'
          - left_val (date/timestamp) the value before the minus in the equation "left - right"
          - right_val (date/timestamp) the value after the minus in the equation "left - right"
          - date_format (pattern) a string pattern for the provided arguments (primarily for BigQuery)
        RETURNS: An integer representing the delta in `part` units
     #}
     {%- set part = part |lower -%}
-    {%if part not in ('day','week','month','year',) %}
+    {%if part not in ('day','week','month','year','quarter',) %}
         {{exceptions.raise_compiler_error("macro datediff for target does not support date part value " ~ part)}}
     {%- endif -%}
 
     {%- if target.type ==  'postgres' -%} 
         {%- if part == 'year' -%}
             DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)
+        {%- elif part == 'quarter' -%}
+            ((DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)) * 4)
+            +
+            (TRUNC((DATE_PART('month',{{left_val}}::DATE) - DATE_PART('month',{{right_val}}::DATE))/4))
         {%- elif part == 'month' -%}
             ((DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)) * 12)
             +

--- a/test_xdb/models/under_test/datediff_test.sql
+++ b/test_xdb/models/under_test/datediff_test.sql
@@ -10,6 +10,6 @@ SELECT
     ,{{ xdb.datediff('week',"'2020-01-16'","base_arg") }} AS two_week_diff
     ,{{ xdb.datediff('month',"'2020-04-02'","base_arg") }} AS three_month_diff
     ,{{ xdb.datediff('year',"'2024-01-01'","base_arg") }} AS four_year_diff
-    ,{{ xdb.datediff('quarter',"'2020-05-01'","base_arg")}} AS five_quarter_diff
+    ,{{ xdb.datediff('quarter',"'2021-05-01'","base_arg")}} AS five_quarter_diff
 FROM
     arguments

--- a/test_xdb/models/under_test/datediff_test.sql
+++ b/test_xdb/models/under_test/datediff_test.sql
@@ -10,5 +10,6 @@ SELECT
     ,{{ xdb.datediff('week',"'2020-01-16'","base_arg") }} AS two_week_diff
     ,{{ xdb.datediff('month',"'2020-04-02'","base_arg") }} AS three_month_diff
     ,{{ xdb.datediff('year',"'2024-01-01'","base_arg") }} AS four_year_diff
+    ,{{ xdb.datediff('quarter',"'2020-05-01'","base_arg")}} AS five_quarter_diff
 FROM
     arguments

--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -67,6 +67,12 @@ models:
               - accepted_values:
                    values: [4]
                    quote: false
+          - name: five_quarter_diff
+            tests:
+              - not_null
+              - accepted_values:
+                   values: [5]
+                   quote: false
 #          - name: five_hour_diff
 #            tests:
 #              - not_null


### PR DESCRIPTION
## Why? 
because we use `DATEDIFF('quarter',a,b)` a lot

## What Changes? 
will calculate the gregorian quarter diff between 2 dates. 

## testing
passes integration tests in snowflake, postgres and BigQuery