### PR TITLE
Fixes conflict in how PG and Snowflake cast

### DIFF
--- a/macros/cast_timestamp.sql
+++ b/macros/cast_timestamp.sql
@@ -28,11 +28,11 @@
         {%- if cast_as in ('timestamp_ntz','timestamp') -%}
             {{val}}::TIMESTAMP_NTZ
         {%- elif cast_as == 'timestamp_tz' -%}
-            {{val}}::TIMESTAMP_TZ
+            TO_TIMESTAMP_TZ(TO_TIMESTAMP_NTZ({{val}})::VARCHAR || '+00', 'YYYY-MM-DD HH24:MI:SS.FFTZH')
         {%- endif %}
         
     {%- else -%}
         {{exceptions.raise_compiler_error("macro does not support datediff for target " ~ target.type ~ ".")}}
     {%- endif -%}
 {%- endmacro -%}
-
+a

--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -80,7 +80,7 @@ models:
             tests:
               - not_null
               - accepted_values:
-                   values: ['2019-12-31 19:00:00 -0800']
+                   values: ['2019-12-31 19:00:00','2020-01-01 00:00:000 -0800']
                    quote: true
           - name: tstamp_tz
             tests:

--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -80,7 +80,7 @@ models:
             tests:
               - not_null
               - accepted_values:
-                   values: ['2019-12-31 19:00:00','2020-01-01 00:00:000 -0800']
+                   values: ['2019-12-31 19:00:00','2020-01-01 00:00:00+00']
                    quote: true
           - name: tstamp_tz
             tests:

--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -86,7 +86,7 @@ models:
             tests:
               - not_null
               - accepted_values:
-                   values: ['2020-01-01 15:20:20', '2020-01-01 20:20:20 -0800']
+                   values: ['2020-01-01 15:20:20', '2020-01-01 20:20:20+00']
                    quote: true
           - name: date_ntz
             tests:

--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -73,21 +73,31 @@ models:
               - accepted_values:
                    values: [5]
                    quote: false
-#          - name: five_hour_diff
-#            tests:
-#              - not_null
-#              - accepted_values:
-#                   values: [5]
-#                   quote: false
-#          - name: six_minute_diff
-#            tests:
-#              - not_null
-#              - accepted_values:
-#                   values: [6]
-#                   quote: false
-#          - name: seven_second_diff
-#            tests:
-#              - not_null
-#              - accepted_values:
-#                   values: [6]
-#                   quote: false
+    - name: cast_timestamp_test
+      description: "tests that timestamps are correctly cast (postgres, snowflake only for ntz)."
+      columns:
+          - name: date_tz
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['2019-12-31 19:00:00 -0800']
+                   quote: true
+          - name: tstamp_tz
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['2020-01-01 15:20:20', '2020-01-01 20:20:20 -0800']
+                   quote: true
+          - name: date_ntz
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['2020-01-01 00:00:00']
+                   quote: true
+          - name: tstamp_ntz
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['2020-01-01 20:20:20']
+                   quote: true
+


### PR DESCRIPTION
## why? 
while working on datediff I found that PG and Snowflake were casting UTC differently - PG was casting the value _as_ UTC, while snowflake was casting it as local time and then converting it to UTC... no Bueno. 

## What changes?
This fixes the two so they cast exactly the same, and adds the disappeared test coverage. 