### PR TITLE
interval_to_timestamp

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -36,6 +36,18 @@ converts `val` to either a timestamp with timezone or a timestamp without timezo
 
 
 **Returns**: 
+### [interval_to_timestamp](../macros/interval_to_timestamp.sql)
+**xdb.interval_to_timestamp** (**part** _string_, **val** _integer representing a unit of time_)
+
+converts and interval `val` to a timestamp
+       *Note* the order of left_val, right_val is reversed from Snowflake.
+
+- part one of 'second', 'minute'
+- val the value
+
+**Returns**:         A string representing the time in HH24:MM:SS format
+    
+
 ### [datediff](../macros/datediff.sql)
 **xdb.datediff** (**part** _string_, **left_val** _date/timestamp_, **right_val** _date/timestamp_, **date_format** _pattern_)
 

--- a/macros/interval_to_timestamp.sql
+++ b/macros/interval_to_timestamp.sql
@@ -1,0 +1,63 @@
+{%- macro interval_to_timestamp(part, val) -%}
+    {# converts and interval `val` to a timestamp
+       *Note* the order of left_val, right_val is reversed from Snowflake.
+       ARGS:
+         - part (string) one of 'second', 'minute'
+         - val (integer representing a unit of time) the value 
+       RETURNS: A string representing the time in HH24:MM:SS format
+    #}
+    {%- set part = part |lower -%}
+    {%if part not in ('second', 'minute',) %}
+        {{exceptions.raise_compiler_error("macro interval_to_timestamp for target does not support date part value " ~ part)}}
+    {%- endif -%}
+
+    {%- if target.type ==  'postgres' -%} 
+        TO_CHAR('{{ val }} {{ part }}'::interval, 'HH24:MI:SS')
+
+
+    {%- elif target.type == 'bigquery' -%}
+        {% if part == 'second' %}
+            case when floor({{ val }} / 3600) < 10 then
+                concat(lpad(cast(floor({{ val }} / 3600) as string), 2, '0'), ':', 
+                lpad(cast(mod(cast(floor({{ val }} / 60) as int64),60) as string), 2, '0'), ':', 
+                lpad(cast(mod({{ val }}, 60) as string), 2, '0'))
+            else 
+                concat(cast(floor({{ val }} / 3600) as string), ':', 
+                lpad(cast(mod(cast(floor({{ val }} / 60) as int64),60) as string), 2, '0'), ':', 
+                lpad(cast(mod({{ val }}, 60) as string), 2, '0'))
+            end
+
+        {% elif part == 'minute' %}
+            case when floor({{ val }} / 60) < 10 then
+                concat(lpad(cast(floor({{ val }} / 60) as string), 2, '0'), ':', 
+                lpad(cast(mod({{ val }}, 60) as string), 2, '0'), ':00')
+            else 
+                concat(cast(floor({{ val }} / 60) as string), ':', 
+                lpad(cast(mod({{ val }}, 60) as string), 2, '0'), ':00')
+            end
+        {%- endif %}
+
+    {%- elif target.type == 'snowflake' -%}
+        {% if part == 'second' %}
+            case when floor({{ val }} / 3600) < 10 then 
+                    concat(lpad(floor({{ val }} / 3600),2,0), ':', 
+                        lpad(floor(({{ val }} / 60) % 60),2,0), ':', 
+                        lpad(floor({{ val }} % 60),2,0))
+                else 
+                    concat(floor({{ val }} / 3600), ':', 
+                        lpad(floor(({{ val }} / 60) % 60),2,0), ':', 
+                        lpad(floor({{ val }} % 60),2,0))
+                end 
+
+        {% elif part == 'minute' %}
+            case when floor({{ val }} / 60) < 10 then 
+                    concat(lpad(floor({{ val }} / 60),2,0), ':', lpad(floor({{ val }} % 60),2,0), ':00')
+                else 
+                    concat(floor({{ val }} / 60), ':', lpad(floor({{ val }} % 60),2,0), ':00')
+                end 
+        {%- endif %}
+
+    {%- else -%}
+        {{exceptions.raise_compiler_error("macro does not support datediff for target " ~ target.type ~ ".")}}
+    {%- endif -%}
+{%- endmacro -%}

--- a/test_xdb/models/under_test/interval_to_timestamp_test.sql
+++ b/test_xdb/models/under_test/interval_to_timestamp_test.sql
@@ -1,0 +1,8 @@
+SELECT 
+    {{ xdb.interval_to_timestamp('second', 3) }} AS three_seconds_second
+    , {{ xdb.interval_to_timestamp('second', 180) }} AS three_minutes_second
+    , {{ xdb.interval_to_timestamp('second', 10800) }} AS three_hours_second
+    , {{ xdb.interval_to_timestamp('second', 120603) }} AS thirty_three_hours_thirty_minutes_three_seconds_second
+    , {{ xdb.interval_to_timestamp('minute', 3) }} AS three_minutes_minute
+    , {{ xdb.interval_to_timestamp('minute', 180) }} AS three_hours_minute
+    , {{ xdb.interval_to_timestamp('minute', 2010) }} AS thirty_three_hours_thirty_minutes_minute

--- a/test_xdb/models/under_test/schema.yml
+++ b/test_xdb/models/under_test/schema.yml
@@ -118,4 +118,49 @@ models:
               - accepted_values:
                    values: ['2020-01-01 20:20:20']
                    quote: true
+    - name: interval_to_timestamp_test
+      description: "tests interval_to_timestamp macro"
+      columns:
+          - name: three_seconds_second
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['00:00:03']
+                   quote: true
+          - name: three_minutes_second
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['00:03:00']
+                   quote: true
+          - name: three_hours_second
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['03:00:00']
+                   quote: true
+          - name: thirty_three_hours_thirty_minutes_three_seconds_second
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['33:30:03']
+                   quote: true
+          - name: three_minutes_minute
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['00:03:00']
+                   quote: true
+          - name: three_hours_minute
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['03:00:00']
+                   quote: true
+          - name: thirty_three_hours_thirty_minutes_minute
+            tests:
+              - not_null
+              - accepted_values:
+                   values: ['33:30:00']
+                   quote: true
 


### PR DESCRIPTION
Adding interval_to_timestamp macro to allow for converting a unit of time (seconds, minutes) into a time stamp (ex. 10000 seconds -> 02:46:40)