### PR TITLE
Add Parenthesis to datediff, dateadd and timeadd

### DIFF
--- a/macros/dateadd.sql
+++ b/macros/dateadd.sql
@@ -1,8 +1,8 @@
 {%- macro dateadd(part, amount_to_add, value) -%}
-    {# adds `amount_to_add` `part`s to `value`. so adding one day to Jan 1 2020 would be dateadd('day',1,'2020-01-01'). 
-       NOTE: dateadd only manipulates date values. for time additions see [timeadd](#timeadd) 
+    {# adds `amount_to_add` `part`s to `value`. so adding one day to Jan 1 2020 would be dateadd('day',1,'2020-01-01').
+       NOTE: dateadd only manipulates date values. for time additions see [timeadd](#timeadd)
        ARGS:
-         - part (string) one of 'day','week','month','year'.  
+         - part (string) one of 'day','week','month','year'.
          - amount_to_add (int) number of `part` units to add to `value`. Negative subtracts.
          - value (string) the date string or column to add to.
        RETURNS: a date value with the amount added.
@@ -15,17 +15,16 @@
         {{exceptions.raise_compiler_error("macro dateadd for target does not support part value " ~ part)}}
     {%- endif -%}
 
-    {%- if target.type ==  'postgres' -%} 
-        {{value}}::DATE + {{amount_to_add}} * INTERVAL '1 {{part}}'
+    {%- if target.type ==  'postgres' -%}
+        (({{value}}::DATE + {{amount_to_add}} * INTERVAL '1 {{part}}'))
 
     {%- elif target.type == 'bigquery' -%}
-        DATE_ADD(CAST({{value}} AS DATE), INTERVAL {{amount_to_add}} {{part|upper}})
+        ((DATE_ADD(CAST({{value}} AS DATE), INTERVAL {{amount_to_add}} {{part|upper}})))
 
     {%- elif target.type == 'snowflake' -%}
-        DATEADD({{part}},{{amount_to_add}},{{value}})     
-          
+        ((DATEADD({{part}},{{amount_to_add}},{{value}})))
+
     {%- else -%}
         {{ xdb.not_supported_exception('dateadd') }}
     {%- endif -%}
 {%- endmacro -%}
-

--- a/macros/datediff.sql
+++ b/macros/datediff.sql
@@ -13,53 +13,52 @@
         {{exceptions.raise_compiler_error("macro datediff for target does not support date part value " ~ part)}}
     {%- endif -%}
 
-    {%- if target.type ==  'postgres' -%} 
+    {%- if target.type ==  'postgres' -%}
         {%- if part == 'year' -%}
-            DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)
+            ((DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)))
         {%- elif part == 'quarter' -%}
-            ((DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)) * 4)
+            ((((DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)) * 4)
             +
-            (TRUNC((DATE_PART('month',{{left_val}}::DATE) - DATE_PART('month',{{right_val}}::DATE))/4))
+            (TRUNC((DATE_PART('month',{{left_val}}::DATE) - DATE_PART('month',{{right_val}}::DATE))/4))))
         {%- elif part == 'month' -%}
-            ((DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)) * 12)
+            ((((DATE_PART('year',{{left_val}}::DATE) - DATE_PART('year',{{right_val}}::DATE)) * 12)
             +
-            (DATE_PART('month',{{left_val}}::DATE) - DATE_PART('month',{{right_val}}::DATE))
+            (DATE_PART('month',{{left_val}}::DATE) - DATE_PART('month',{{right_val}}::DATE))))
         {%- elif part == 'week' -%}
-            TRUNC(DATE_PART('day', ({{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP))/7)
+            ((TRUNC(DATE_PART('day', ({{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP))/7)))
         {%- elif part == 'day' -%}
-            DATE_PART('day', ({{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP))
+            ((DATE_PART('day', ({{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP))))
         {%- elif part =='hour' -%}
-            {{ xdb.datediff('day', left_val, right_val) }} * 24 
-            + 
-            DATE_PART('hour', {{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP)
+            (({{ xdb.datediff('day', left_val, right_val) }} * 24
+            +
+            DATE_PART('hour', {{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP)))
         {%- elif part =='minute' -%}
-            {{ xdb.datediff('hour', left_val, right_val) }} * 60
-            + 
-            DATE_PART('minute', {{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP)
+            (({{ xdb.datediff('hour', left_val, right_val) }} * 60
+            +
+            DATE_PART('minute', {{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP)))
         {%- elif part =='second' -%}
-            {{ xdb.datediff('minute', left_val, right_val) }} * 60
-            + 
-            DATE_PART('second', {{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP)
+            (({{ xdb.datediff('minute', left_val, right_val) }} * 60
+            +
+            DATE_PART('second', {{left_val}}::TIMESTAMP - {{right_val}}::TIMESTAMP)))
         {%- endif %}
 
 
     {%- elif target.type == 'bigquery' -%}
         {% if part in ('second', 'minute', 'hour') %}
-            TIMESTAMP_DIFF(PARSE_TIMESTAMP('{{date_format}}', FORMAT_TIMESTAMP('{{date_format}}', {{ xdb.cast_timestamp(left_val, 'timestamp') }})), 
-                      PARSE_TIMESTAMP('{{date_format}}', FORMAT_TIMESTAMP('{{date_format}}', {{ xdb.cast_timestamp(right_val, 'timestamp') }})), 
-                      {{part|upper}})
+            ((TIMESTAMP_DIFF(PARSE_TIMESTAMP('{{date_format}}', FORMAT_TIMESTAMP('{{date_format}}', {{ xdb.cast_timestamp(left_val, 'timestamp') }})),
+                      PARSE_TIMESTAMP('{{date_format}}', FORMAT_TIMESTAMP('{{date_format}}', {{ xdb.cast_timestamp(right_val, 'timestamp') }})),
+                      {{part|upper}})))
         {% else %}
-            DATE_DIFF(PARSE_DATE('{{date_format}}', {{left_val}}), 
-                      PARSE_DATE('{{date_format}}', {{right_val}}), 
-                      {{part|upper}})
+            ((DATE_DIFF(PARSE_DATE('{{date_format}}', {{left_val}}),
+                      PARSE_DATE('{{date_format}}', {{right_val}}),
+                      {{part|upper}})))
         {%- endif %}
 
     {%- elif target.type == 'snowflake' -%}
 
-        DATEDIFF('{{part}}', {{right_val}},{{left_val}})
+        ((DATEDIFF('{{part}}', {{right_val}},{{left_val}})))
 
     {%- else -%}
         {{ xdb.not_supported_exception('datediff') }}
     {%- endif -%}
 {%- endmacro -%}
-

--- a/macros/timeadd.sql
+++ b/macros/timeadd.sql
@@ -1,8 +1,8 @@
 {%- macro timeadd(part, amount_to_add, value) -%}
-    {# adds `amount_to_add` `part`s to `value`. so adding one hour to Jan 1 2020 01:00:00 would be timeadd('hour',1,'2020-01-01 01:00:00'). 
-       NOTE: timeadd only manipulates time values. for date additions see [dateadd](#dateadd) 
+    {# adds `amount_to_add` `part`s to `value`. so adding one hour to Jan 1 2020 01:00:00 would be timeadd('hour',1,'2020-01-01 01:00:00').
+       NOTE: timeadd only manipulates time values. for date additions see [dateadd](#dateadd)
        ARGS:
-         - part (string) one of 'second','minute','hour'.  
+         - part (string) one of 'second','minute','hour'.
          - amount_to_add (int) number of `part` units to add to `value`. Negative subtracts.
          - value (string) the date time string or column to add to.
        RETURNS: a date time value with the amount added.
@@ -15,17 +15,16 @@
         {{exceptions.raise_compiler_error("macro timeadd for target does not support part value " ~ part)}}
     {%- endif -%}
 
-    {%- if target.type ==  'postgres' -%} 
-        {{value}}::TIMESTAMP + {{amount_to_add}} * INTERVAL '1 {{part}}'
+    {%- if target.type ==  'postgres' -%}
+       (( {{value}}::TIMESTAMP + {{amount_to_add}} * INTERVAL '1 {{part}}'))
 
     {%- elif target.type == 'bigquery' -%}
-        TIMESTAMP_ADD(CAST({{value}} AS TIMESTAMP), INTERVAL {{amount_to_add}} {{part|upper}})
+        ((TIMESTAMP_ADD(CAST({{value}} AS TIMESTAMP), INTERVAL {{amount_to_add}} {{part|upper}})))
 
     {%- elif target.type == 'snowflake' -%}
-        DATEADD({{part}},{{amount_to_add}},{{value}}::TIMESTAMP)     
-          
+        ((DATEADD({{part}},{{amount_to_add}},{{value}}::TIMESTAMP)))
+
     {%- else -%}
         {{exceptions.raise_compiler_error("macro does not support dateadd for target " ~ target.type ~ ".")}}
     {%- endif -%}
 {%- endmacro -%}
-


### PR DESCRIPTION
## What is this? 
Adding parenthesis to allow some datediff, dateadd and timeadd to be used inside one another.

## What changes in this PR? 
* Added parenthesis around parts of code

## How does this impact our users?
* They will now be allow to use datediff, dateadd and timeadd within other UDF's.

## PR Quality
- [ ] does `docker-compose exec testxdb test` run successfully?
- [ ] does `docker-compose exec testxdb docs` build docs without errors?
- [ ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ ] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!