### PR TITLE
Changes how concat treats NULL values

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -5,7 +5,7 @@ These macros carry functionality across **Snowflake**, **Postgresql**, **Redshif
 
 
 ### [_concat_cast_fields](../macros/concat.sql)
-**xdb._concat_cast_fields** (**fields** _None_)
+**xdb._concat_cast_fields** (**fields** _None_, **convert_null** _None_)
 
 
 
@@ -88,7 +88,7 @@ converts `val` to either a timestamp with timezone or a timestamp without timezo
 ### [dateadd](../macros/dateadd.sql)
 **xdb.dateadd** (**part** _string_, **amount_to_add** _int_, **value** _string_)
 
-adds `amount_to_add` `part`s to `value`. so adding one day to Jan 1 2020 would be dateadd('day',1,'2020-01-01'). 
+adds `amount_to_add` `part`s to `value`. so adding one day to Jan 1 2020 would be dateadd('day',1,'2020-01-01').
        NOTE: dateadd only manipulates date values. for time additions see [timeadd](#timeadd)
 
 - part one of 'day','week','month','year'.
@@ -174,6 +174,19 @@ counts how many instances of `pattern` in `value`
 
 
 **Returns**: 
+### [timeadd](../macros/timeadd.sql)
+**xdb.timeadd** (**part** _string_, **amount_to_add** _int_, **value** _string_)
+
+adds `amount_to_add` `part`s to `value`. so adding one hour to Jan 1 2020 01:00:00 would be timeadd('hour',1,'2020-01-01 01:00:00').
+       NOTE: timeadd only manipulates time values. for date additions see [dateadd](#dateadd)
+
+- part one of 'second','minute','hour'.
+- amount_to_add number of `part` units to add to `value`. Negative subtracts.
+- value the date time string or column to add to.
+
+**Returns**:         a date time value with the amount added.
+    
+
 ### [using](../macros/using.sql)
 **xdb.using** (**rel_1** _None_, **rel_2** _None_, **col** _None_)
 

--- a/test_xdb/models/schema_tests/concat.yml
+++ b/test_xdb/models/schema_tests/concat.yml
@@ -52,3 +52,14 @@ models:
                   values: ['2020-01-01-1239-test@example.com-1.23']
                   quote: true
               - not_null    
+          - name: has_null_field
+            tests:
+              - accepted_values:
+                  values: ['1239-NULL-some-text, in here!']
+                  quote: true
+              - not_null    
+          - name: all_null
+            tests:
+              - accepted_values:
+                  values: ['NULL']
+                  quote: false

--- a/test_xdb/models/under_test/concat_test.sql
+++ b/test_xdb/models/under_test/concat_test.sql
@@ -1,7 +1,7 @@
 {%- set all_fields = ['date_col','int_col','email_col','text_col','float_col'] -%}
 {%- set all_fields_order = ['text_col','date_col','email_col','float_col','int_col'] -%}
 {%- set partial_fields = ['date_col','int_col','email_col','float_col'] -%}
-
+{%- set has_null_field = ['int_col','null_col','text_col'] -%}
 WITH source_data AS (
     SELECT
         cast('2020-01-01' as date) AS date_col
@@ -9,6 +9,7 @@ WITH source_data AS (
         , 'test@example.com' as email_col
         , 'some-text, in here!' as text_col
         , cast(1.23 as float{{ '64' if target.type == 'bigquery'}} ) as float_col
+        ,cast(NULL AS {{ 'STRING' if target.type == 'bigquery' else 'VARCHAR'}}) as null_col
 )
 SELECT
     {{ xdb.concat(all_fields) }} as all_fields_no_sep
@@ -19,6 +20,8 @@ SELECT
     , {{ xdb.concat(all_fields, ':') }} as all_fields_colon_sep
     , {{ xdb.concat(partial_fields) }} as partial_fields_no_sep
     , {{ xdb.concat(partial_fields, '-') }} as partial_fields_dash_sep
+    , {{ xdb.concat(has_null_field,'-') }} as has_null_field
+    , {{ xdb.concat(has_null_field,'-',false) }} as all_null
 FROM
     source_data
 


### PR DESCRIPTION
## What is this? 
This gives concat the option to treat nulls as strings, or pass them directly to the target. Default is now to convert them and preserve the concat'd string. 

## What changes in this PR? 
* `convert_null` defaults to True. When set to False `NULL` will be passed directly. 

## How does this impact our users?
#40  ✔️  
This is a _breaking_ change, if you depended on the old default NULL behavior it will need to be explicitly set now.

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully?
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!