### PR TITLE
updated strip and added fold

### DIFF
--- a/macros/fold.sql
+++ b/macros/fold.sql
@@ -1,0 +1,22 @@
+
+{%- macro fold(val) -%}
+   {{ xdb.strip_to_single_line(xdb._fold(val)) }}
+{%- endmacro -%}
+
+
+{%- macro _fold(val) -%}
+    /*{# folds a value per the target adapter default.
+    ARGS:
+      - val(string): the value to be folded.
+    RETURNS: `val` either upper or lowercase (or unfolded), per the target adapter spec.
+   #}*/
+    {%- if target.type == 'postgres' -%}
+        {{ val | lower }} 
+    {%- elif target.type == 'snowflake' -%}
+        {{ val | upper }} 
+    {%- elif target.type == 'bigquery' -%}
+        {{ val }} 
+    {%- else -%}
+        {{ xdb.not_supported_exception('fold') }}
+    {%- endif -%}
+{%- endmacro %}

--- a/macros/utilities/strip_to_single_line.sql
+++ b/macros/utilities/strip_to_single_line.sql
@@ -1,4 +1,4 @@
 {# this removes all side-effect formatting from nested macros, producing a single line sql statement #}
 {%- macro strip_to_single_line(str) -%}
-    {{str | replace('/*','') | replace('*/','') | replace('\n','') | replace(' ','') }}
+    {{ str | replace('/*',' ') | replace('*/',' ') | replace('\n',' ') }}
 {%- endmacro -%}

--- a/test_xdb/models/schema_tests/fold.yml
+++ b/test_xdb/models/schema_tests/fold.yml
@@ -1,0 +1,11 @@
+version: 2
+
+models:
+    - name: fold_test
+      description: "tests correct case folding"
+      columns:
+          - name: folded_value
+            tests:
+              - accepted_values:
+                  values: ['postgres','SNOWFLAKE','BiGQuery']
+                  quote: true

--- a/test_xdb/models/under_test/fold_test.sql
+++ b/test_xdb/models/under_test/fold_test.sql
@@ -1,0 +1,8 @@
+SELECT
+    {%- if target.type == "bigquery" -%}
+        {{ xdb.fold("'BiGQuery'") }} AS folded_value
+    {%- elif target.type == "postgres" -%}
+        {{ xdb.fold("'PostGres'") }} AS folded_value
+    {%- elif target.type == "snowflake" -%}
+        {{ xdb.fold("'SnowFlake'") }} AS folded_value
+    {%- endif -%}

--- a/test_xdb/profiles.yml
+++ b/test_xdb/profiles.yml
@@ -7,7 +7,7 @@ default:
       method: service-account
       project: "{{ env_var('BIGQUERY_PROJECT') }}"
       dataset: testxdb
-      threads: 1
+      threads: 24
       keyfile: /app/keyfile.json
       timeout_seconds: 300
       priority: interactive
@@ -15,7 +15,7 @@ default:
 
     postgres:
       type: postgres
-      threads: 1
+      threads: 24
       host: testxdb_postgres
       port: 5432
       user: testxdb
@@ -35,7 +35,7 @@ default:
 
     snowflake:
       type: snowflake
-      threads: 1
+      threads: 24
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('SNOWFLAKE_USERNAME') }}"
       password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"


### PR DESCRIPTION
## What is this? 
This adds the ability to flat "fold" values to match the natural folding of the RDBMS. in Postgres unquoted things default to lowercase, this makes them lowercase. in Snowflake it makes them uppercase.

## What changes in this PR? 
* adds fold macro
* cleans up how the `strip_to_single_line` macro scrubs comments and newlines

## How does this impact our users?
makes it easy to deal with db casing. note that this doesn't quote things - so it can be used for identifiers OR strings! 

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully?
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 

This closes #24 


@Health-Union/hu-data make sure to include a version tag in the merge commit!