### PR TITLE
Pins to DBT v0.17.1-rc4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 RUN apt-get update -y && \
 apt-get install -y vim && \
-pip3 install dbt && \ 
+pip3 install dbt==0.17.1-rc4 && \ 
 mkdir /app && \
 mkdir /dbt-xdb 
 


### PR DESCRIPTION
## What is this? 
We allowed the DBT version to float in the dockerfile until now. 

## What changes in this PR? 
DBT is pinned at v0.17.1-rc4

## How does this impact our users?
At the moment this version represents the stable build (0.17.0) + regression fixes XDB needs to function (namely data type introspection in schema test accepted_values)

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully?
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 


*Note*: we should def consider using a cyclical build for deployment testing (maybe TOX based?) that rotates dbt versions and tags each supported version :) 


@Health-Union/hu-data make sure to include a version tag in the merge commit!