### PR TITLE
Updated to include recrusive_cte macro with tests

### DIFF
--- a/macros/recursive_cte.sql
+++ b/macros/recursive_cte.sql
@@ -1,0 +1,15 @@
+{%- macro recursive_cte() -%}
+    {# Supplies the correct wrapper for recursive CTEs in postgres & snowflake
+       NOTE: Bigquery does not currently support recursive CTEs per their docs
+       ARGS:
+         - none
+       RETURNS: The correct wrapper for the CTE
+    #}
+    {%- if target.type ==  'postgres' -%} 
+        WITH RECURSIVE 
+    {%- elif target.type == 'snowflake' -%}
+        WITH 
+    {%- else -%}
+        {{ xdb.not_supported_exception('quote_insensitive') }}
+    {%- endif -%}
+{%- endmacro -%}

--- a/test_xdb/models/schema_tests/recursive_cte.yml
+++ b/test_xdb/models/schema_tests/recursive_cte.yml
@@ -1,0 +1,11 @@
+version: 2
+
+models:
+    - name: recursive_cte
+      description: "tests that recursive ctes are working correctly."
+      columns:
+          - name: n
+            tests:
+              - accepted_values:
+                  values: [0,1,2,3]
+                  quote: false

--- a/test_xdb/models/under_test/recursive_cte.sql
+++ b/test_xdb/models/under_test/recursive_cte.sql
@@ -1,0 +1,20 @@
+{{ config(tags=["exclude_bigquery_tests"]) }}
+{% if target.type == 'bigquery' %}
+    select 'Bigquery Does Not Support Recursive CTEs' as n
+
+{% else %}
+
+    {{ xdb.recursive_cte() }} cte_test(n) AS (
+        SELECT 0
+
+        UNION ALL
+
+        SELECT n+1
+        FROM cte_test
+        where n < 3
+    )
+
+    SELECT n
+    FROM cte_test
+
+{% endif %}


### PR DESCRIPTION
## What is this? 
This update adds the recursive_cte macros

## What changes in this PR? 
* The recursive_cte macro now works!

## How does this impact our users?
* They can now use recursive_cte's in postgres and snowflake (bigquery does not support recursive cte's)

## PR Quality
- [ x] does `docker-compose exec testxdb test` run successfully?
- [ x] does `docker-compose exec testxdb docs` build docs without errors?
- [ x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ x] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!