### PR TITLE
Updates to generate_daily_time_series_values macro

### DIFF
--- a/macros/generate_daily_time_series_values.sql
+++ b/macros/generate_daily_time_series_values.sql
@@ -10,7 +10,7 @@
     {%- if target.type in ['postgres'] -%} 
         generate_series
     {%- elif target.type == 'snowflake' -%}
-        dateadd(day, '+' || row_number() over (order by seq4()), TO_DATE('{{ start_date }}') - INTERVAL '1 day')
+        dateadd(day, '+' || row_number() over (order by seq4()), TO_TIMESTAMP('{{ start_date }}') - INTERVAL '1 day')
     {%- else -%}
         {{ xdb.not_supported_exception('generate_time_series_values') }}
     {%- endif -%}

--- a/macros/generate_daily_time_series_values.sql
+++ b/macros/generate_daily_time_series_values.sql
@@ -10,7 +10,7 @@
     {%- if target.type in ['postgres'] -%} 
         generate_series
     {%- elif target.type == 'snowflake' -%}
-        dateadd(day, '-' || seq4(), '{{ stop_date }}')
+        dateadd(day, '+' || row_number() over (order by seq4()), TO_DATE('{{ start_date }}') - INTERVAL '1 day')
     {%- else -%}
         {{ xdb.not_supported_exception('generate_time_series_values') }}
     {%- endif -%}


### PR DESCRIPTION
## What is this? 
Updates to generate_daily_time_series_values macro:
1. Match behavior of postgres by outputting timestamps (instead of dates) in ascending order
2. Use row_number() approach to generating sequence so as to avoid possibility of gaps in sequence, As described here: https://docs.snowflake.com/en/sql-reference/functions/seq1.html

Postgres and Snowflake tests pass



@Health-Union/hu-data make sure to include a version tag in the merge commit!