### PR TITLE
Update to add an array_index macro that standardizes array_index acro…

### DIFF
--- a/macros/array_index.sql
+++ b/macros/array_index.sql
@@ -1,0 +1,18 @@
+{%- macro array_index(index) -%}
+  /*{# This macro takes a number and adjusts the index based on programming language. We use 0
+        index because we're rational human beings
+    ARGS:
+        - Index (int) the 0 based index to convert
+    RETURNS: The right position for the right database
+    #}*/
+
+    {%- if target.type == 'postgres' -%} 
+	{{ (index + 1) }}
+    {%- elif target.type == 'snowflake' -%}
+    {{ index }}
+    {%- elif target.type == 'bigquery' -%}
+    offset({{ index }})
+    {%- else -%}
+        {{ xdb.not_supported_exception('any_value') }}
+    {%- endif -%}
+{%- endmacro -%}

--- a/test_xdb/models/schema_tests/array_index_test.yml
+++ b/test_xdb/models/schema_tests/array_index_test.yml
@@ -1,0 +1,11 @@
+version: 2
+
+models:
+    - name: array_index_test
+      description: "tests array index"
+      columns:
+          - name: value_col
+            tests:
+              - accepted_values:
+                  values: ['a']
+                  quote: true

--- a/test_xdb/models/under_test/array_index_test.sql
+++ b/test_xdb/models/under_test/array_index_test.sql
@@ -1,0 +1,17 @@
+WITH starter_values AS (
+	SELECT 0 AS index_column, 'a' AS val
+	UNION ALL 
+	SELECT 0 AS index_column, 'b' AS val
+	UNION ALL 
+	SELECT 0 AS index_column, 'c' AS val
+)
+
+, array_agg_values AS (
+    SELECT index_column
+    , ARRAY_AGG(val) AS array_values
+    FROM starter_values
+    GROUP BY 1
+)
+
+SELECT array_values[ {{xdb.array_index(0) }}] AS value_col
+FROM array_agg_values


### PR DESCRIPTION
…ss database platforms.

## What is this? 
Standardizes array indexing across supported databases (all arrays start at 0)

## What changes in this PR? 
* Added the array_index macro

## How does this impact our users?
* Helps standardize their code by providing a standardized array index across databases

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully?
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [ ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ ] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!