### PR TITLE
Feature/support dbt 19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 RUN apt-get update -y && \
 apt-get install -y vim && \
-pip3 install dbt==0.17.1-rc4 && \ 
+pip3 install dbt==0.19.0 && \ 
 mkdir /app && \
 mkdir /dbt-xdb 
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,5 @@
 name: 'xdb'
+config-version: 2
 version: '0.0.1'
 macro-paths: ["macros"]
 clean-targets: ["target","dbt_modules"]

--- a/test_xdb/dbt_project.yml
+++ b/test_xdb/dbt_project.yml
@@ -1,4 +1,5 @@
 name: 'test_xdb'
+config-version: 2
 version: '0.0.1'
 profile: 'default'
 source-paths: ["models"]

--- a/test_xdb/models/under_test/cast_timestamp_test.sql
+++ b/test_xdb/models/under_test/cast_timestamp_test.sql
@@ -1,4 +1,4 @@
-{{ config(tags=["exclude_bigquery_tests"]) }}
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
 
 WITH 
 source_data AS (

--- a/test_xdb/models/under_test/generate_daily_time_series_test.sql
+++ b/test_xdb/models/under_test/generate_daily_time_series_test.sql
@@ -1,3 +1,4 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
 SELECT 
     {{ xdb.generate_daily_time_series_values('2020-01-01', '2020-01-05') }} AS one_day_diff
 FROM

--- a/test_xdb/models/under_test/get_time_slice_test.sql
+++ b/test_xdb/models/under_test/get_time_slice_test.sql
@@ -1,33 +1,39 @@
-WITH
-timestamps AS (
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+{% if target.type == 'bigquery' %}
+    select 'Bigquery does not support time slices at this time.' as n
+
+{% else %}
+    WITH
+    timestamps AS (
+        SELECT
+            '2019-01-01 14:00:00'::timestamp AS ts
+        UNION ALL
+        SELECT
+            '2019-01-01 14:00:00 -0500'::timestamp AS ts
+        UNION ALL
+        SELECT
+            '2019-01-01 14:00:00 +0200'::timestamp AS ts
+    )
+    
     SELECT
-        '2019-01-01 14:00:00'::timestamp AS ts
-    UNION ALL
-    SELECT
-        '2019-01-01 14:00:00 -0500'::timestamp AS ts
-    UNION ALL
-    SELECT
-        '2019-01-01 14:00:00 +0200'::timestamp AS ts
-)
-   
-SELECT
-    {{ xdb.get_time_slice('ts::timestamp', 1, 'MINUTE', 'START') }} AS one_minute_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 1, 'MINUTE', 'END') }} AS one_minute_slice_end
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'MINUTE', 'START') }} AS ten_minute_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'MINUTE', 'END') }} AS ten_minute_slice_end
-   , {{ xdb.get_time_slice('ts::timestamp', 1, 'HOUR', 'START') }} AS one_hour_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 1, 'HOUR', 'END') }} AS one_hour_slice_end
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'HOUR', 'START') }} AS ten_hour_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'HOUR', 'END') }} AS ten_hour_slice_end
-   , {{ xdb.get_time_slice('ts::timestamp', 1, 'DAY', 'START') }} AS one_day_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 1, 'DAY', 'END') }} AS one_day_slice_end
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'DAY', 'START') }} AS ten_day_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'DAY', 'END') }} AS ten_day_slice_end
--- Can't figure out how to get postgres and snowflake to give same answers for week and month
--- Quarter?
-   , {{ xdb.get_time_slice('ts::timestamp', 1, 'YEAR', 'START') }} AS one_year_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 1, 'YEAR', 'END') }} AS one_year_slice_end
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'YEAR', 'START') }} AS ten_year_slice_start
-   , {{ xdb.get_time_slice('ts::timestamp', 10, 'YEAR', 'END') }} AS ten_year_slice_end
-FROM
-   timestamps
+        {{ xdb.get_time_slice('ts::timestamp', 1, 'MINUTE', 'START') }} AS one_minute_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 1, 'MINUTE', 'END') }} AS one_minute_slice_end
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'MINUTE', 'START') }} AS ten_minute_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'MINUTE', 'END') }} AS ten_minute_slice_end
+    , {{ xdb.get_time_slice('ts::timestamp', 1, 'HOUR', 'START') }} AS one_hour_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 1, 'HOUR', 'END') }} AS one_hour_slice_end
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'HOUR', 'START') }} AS ten_hour_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'HOUR', 'END') }} AS ten_hour_slice_end
+    , {{ xdb.get_time_slice('ts::timestamp', 1, 'DAY', 'START') }} AS one_day_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 1, 'DAY', 'END') }} AS one_day_slice_end
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'DAY', 'START') }} AS ten_day_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'DAY', 'END') }} AS ten_day_slice_end
+    -- Can't figure out how to get postgres and snowflake to give same answers for week and month
+    -- Quarter?
+    , {{ xdb.get_time_slice('ts::timestamp', 1, 'YEAR', 'START') }} AS one_year_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 1, 'YEAR', 'END') }} AS one_year_slice_end
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'YEAR', 'START') }} AS ten_year_slice_start
+    , {{ xdb.get_time_slice('ts::timestamp', 10, 'YEAR', 'END') }} AS ten_year_slice_end
+    FROM
+    timestamps
+{% endif %}

--- a/test_xdb/models/under_test/last_value_test.sql
+++ b/test_xdb/models/under_test/last_value_test.sql
@@ -1,3 +1,4 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
 WITH
 test_data AS (
     SELECT

--- a/test_xdb/models/under_test/linear_interpolate_test.sql
+++ b/test_xdb/models/under_test/linear_interpolate_test.sql
@@ -1,3 +1,4 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
 WITH
 inputs AS (
     SELECT

--- a/test_xdb/models/under_test/recursive_cte.sql
+++ b/test_xdb/models/under_test/recursive_cte.sql
@@ -1,4 +1,5 @@
-{{ config(tags=["exclude_bigquery_tests"]) }}
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+
 {% if target.type == 'bigquery' %}
     select 'Bigquery Does Not Support Recursive CTEs' as n
 

--- a/test_xdb/models/under_test/timestamp_to_date_part_test.sql
+++ b/test_xdb/models/under_test/timestamp_to_date_part_test.sql
@@ -1,3 +1,4 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
 WITH
     test_data AS (
     SELECT 


### PR DESCRIPTION
## What is this? 
This improves the BigQuery tagging and moves both test and package configs up to dbt 0.19.0! 

## What changes in this PR? 
- added missing bigquery flags
- bumped and tested with dbt 0.19.0
- added config versions

## How does this impact our users?
* Users can now use this package with the most current release of DBT

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully?
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [ ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 

There are a handful of macros with no test coverage from previous versions :( will open a new PR to address. 


@Health-Union/hu-data make sure to include a version tag in the merge commit!