### PR TITLE
Add simple json field extraction

### DIFF
--- a/macros/extract_json_path.sql
+++ b/macros/extract_json_path.sql
@@ -1,0 +1,44 @@
+{% macro extract_json_path(column, path_vals) %}
+  {#
+    Extracts the value at `path_vals` from the json typed `column` (or expression)
+       ARGS:
+         - `column` (string) the column name (or expression) to extract the values from
+         - `path_vals` (list[string/int]) the path to the desired value. 
+           Strings values are assumed to be keys
+           Integer values are assumed to index arrays
+           Integers that are typed as strings are assumed to be keys
+
+       RETURNS: (varchar) The value at the given path in the column value
+  #}
+  {% if target.type == 'postgres' %}
+    {% set expr = namespace(value=column) %}
+    {% for val in path_vals %}
+      {% if val is integer %}
+        {% set append_val = val %}
+      {% else %}
+        {% set append_val = "'" ~ val ~ "'" %}
+      {% endif %}
+
+      {% if loop.last %}
+        {% set expr.value = expr.value ~ '->>' ~ append_val %}
+      {% else %}
+        {% set expr.value = expr.value ~ '->' ~ append_val %}
+      {% endif %}
+    {% endfor %}
+  {% elif target.type == 'snowflake' %}
+    {% set expr = namespace(value=column ~ ':') %}
+    {% for val in path_vals %}
+      {% if val is integer %}
+        {% set append_val = val %}
+        {% set expr.value = expr.value ~ '[' ~ append_val ~ ']' %}
+      {% else %}
+        {% set append_val = "'" ~ val ~ "'" %}
+        {% set expr.value = expr.value ~ '.' ~ append_val %}
+      {% endif %}
+    {% endfor %}
+    {% set expr.value = expr.value ~ '::text' %}
+  {% else %}
+    {{raise_not_supported_error()}}
+  {% endif %}
+  {{ return(expr.value) }}
+{% endmacro %}

--- a/macros/json_extract_path_text.sql
+++ b/macros/json_extract_path_text.sql
@@ -1,4 +1,4 @@
-{% macro json_extract_path_text(column, path_vals) %}
+{%- macro json_extract_path_text(column, path_vals) -%}
   {#
     Extracts the value at `path_vals` from the json typed `column` (or expression)
        ARGS:
@@ -13,33 +13,34 @@
 
        RETURNS: (varchar) The value at the given path in the column value
   #}
-  {% if target.type == 'postgres' %}
-    {% set expr = namespace(value="json_extract_path_text(" ~ column ~ ", ") %}
-    {% for val in path_vals %}
-      {% set expr.value = expr.value ~ "'" ~ val ~ "'" %}
-      {% if not loop.last %}
-        {% set expr.value = expr.value ~ ", " %}
-      {% endif %}
-    {% endfor %}
-    {% set expr.value = expr.value ~ ")" %}
-  {% elif target.type == 'snowflake' %}
-    {% set expr = namespace(value="json_extract_path_text(" ~ column ~ ", '") %}
-    {% for val in path_vals %}
-      {% if val is integer %}
-        {% set append_val = val %}
-        {% set expr.value = expr.value ~ '[' ~ append_val ~ ']' %}
-      {% else %}
-        {% if not loop.first %}
+  {%- if target.type == 'postgres' -%}
+    {%- set expr = namespace(value="json_extract_path_text(" ~ column ~ ", ") -%}
+    {%- for val in path_vals -%}
+      {%- set expr.value = expr.value ~ "'" ~ val ~ "'" -%}
+      {%- if not loop.last -%}
+        {%- set expr.value = expr.value ~ ", " -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- set expr.value = expr.value ~ ")" -%}
+  {%- elif target.type == 'snowflake' -%}
+    {%- set expr = namespace(value="json_extract_path_text(" ~ column ~ ", '") -%}
+    {%- for val in path_vals -%}
+      {%- if val is integer -%}
+        {%- set append_val = val -%}
+        {%- set expr.value = expr.value ~ '[' ~ append_val ~ ']' -%}
+      {%- else -%}
+        {%- if not loop.first -%}
           {# no . for first item #}
-          {% set expr.value = expr.value ~ '."' ~ val ~ '"' %}
-        {% else %}
-          {% set expr.value = expr.value ~ '"' ~ val ~ '"' %}
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-    {% set expr.value = expr.value ~ "')" %}
-  {% else %}
-    {{raise_not_supported_error()}}
-  {% endif %}
+          {%- set expr.value = expr.value ~ '."' ~ val ~ '"' -%}
+        {%- else -%}
+          {%- set expr.value = expr.value ~ '"' ~ val ~ '"' -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- set expr.value = expr.value ~ "')" -%}
+  {%- else -%}
+    {%- set expr = namespace(value='') -%}
+    {{ xdb.not_supported_exception('json_extract_path_text') }}
+  {%- endif -%}
   {{ return(expr.value) }}
-{% endmacro %}
+{%- endmacro -%}

--- a/macros/json_extract_path_text.sql
+++ b/macros/json_extract_path_text.sql
@@ -1,4 +1,4 @@
-{% macro extract_json_path(column, path_vals) %}
+{% macro json_extract_path_text(column, path_vals) %}
   {#
     Extracts the value at `path_vals` from the json typed `column` (or expression)
        ARGS:
@@ -8,35 +8,31 @@
            Integer values are assumed to index arrays
            Integers that are typed as strings are assumed to be keys
 
+           Note that in some DB cases it does not matter the typing:
+            - postgres: '0' will indicate the key "0" or first array item based on context
+
        RETURNS: (varchar) The value at the given path in the column value
   #}
   {% if target.type == 'postgres' %}
-    {% set expr = namespace(value=column) %}
+    {% set expr = namespace(value="json_extract_path_text(" ~ column ~ ", ") %}
     {% for val in path_vals %}
-      {% if val is integer %}
-        {% set append_val = val %}
-      {% else %}
-        {% set append_val = "'" ~ val ~ "'" %}
-      {% endif %}
-
-      {% if loop.last %}
-        {% set expr.value = expr.value ~ '->>' ~ append_val %}
-      {% else %}
-        {% set expr.value = expr.value ~ '->' ~ append_val %}
+      {% set expr.value = expr.value ~ "'" ~ append_val ~ "'" %}
+      {% if not loop.last %}
+        {% set expr.value = expr.value ~ ", " %}
       {% endif %}
     {% endfor %}
+    {% set expr.value = expr.value ~ ")" %}
   {% elif target.type == 'snowflake' %}
-    {% set expr = namespace(value=column ~ ':') %}
+    {% set expr = namespace(value="json_extract_path_text(" ~ column ~ ", '") %}
     {% for val in path_vals %}
       {% if val is integer %}
         {% set append_val = val %}
         {% set expr.value = expr.value ~ '[' ~ append_val ~ ']' %}
       {% else %}
-        {% set append_val = "'" ~ val ~ "'" %}
-        {% set expr.value = expr.value ~ '.' ~ append_val %}
+        {% set expr.value = expr.value ~ '."' ~ append_val ~ '"' %}
       {% endif %}
     {% endfor %}
-    {% set expr.value = expr.value ~ '::text' %}
+    {% set expr.value = expr.value ~ ')' %}
   {% else %}
     {{raise_not_supported_error()}}
   {% endif %}

--- a/macros/json_extract_path_text.sql
+++ b/macros/json_extract_path_text.sql
@@ -16,7 +16,7 @@
   {% if target.type == 'postgres' %}
     {% set expr = namespace(value="json_extract_path_text(" ~ column ~ ", ") %}
     {% for val in path_vals %}
-      {% set expr.value = expr.value ~ "'" ~ append_val ~ "'" %}
+      {% set expr.value = expr.value ~ "'" ~ val ~ "'" %}
       {% if not loop.last %}
         {% set expr.value = expr.value ~ ", " %}
       {% endif %}
@@ -29,10 +29,15 @@
         {% set append_val = val %}
         {% set expr.value = expr.value ~ '[' ~ append_val ~ ']' %}
       {% else %}
-        {% set expr.value = expr.value ~ '."' ~ append_val ~ '"' %}
+        {% if not loop.first %}
+          {# no . for first item #}
+          {% set expr.value = expr.value ~ '."' ~ val ~ '"' %}
+        {% else %}
+          {% set expr.value = expr.value ~ '"' ~ val ~ '"' %}
+        {% endif %}
       {% endif %}
     {% endfor %}
-    {% set expr.value = expr.value ~ ')' %}
+    {% set expr.value = expr.value ~ "')" %}
   {% else %}
     {{raise_not_supported_error()}}
   {% endif %}

--- a/test_xdb/models/schema_tests/json_extract_path_text_test.yml
+++ b/test_xdb/models/schema_tests/json_extract_path_text_test.yml
@@ -6,39 +6,48 @@ models:
       columns:
           - name: key1__val
             tests:
+              - not_null
               - accepted_values:
                   values: ['value1']
           - name: key2__val
             tests:
+              - not_null
               - accepted_values:
-                  values: ['{"innerkey2_1":"innervalue2_1", "0":[0, null, "string"]}']
+                  values: [53]
+                  quote: false
           - name: key2_innerkey2_1__val
             tests:
+              - not_null
               - accepted_values:
                   values: ['innervalue2_1']
           - name: key2_0__val
             tests:
+              - not_null
               - accepted_values:
-                  values: ['[0, null, "string"]']
+                  values: ['[0,null,"string"]']
           - name: key2_0__val_0
             tests:
+              - not_null
               - accepted_values:
                   values: ['0']
           - name: key2_0__val_1
             tests:
               - accepted_values:
-                  values: ['']
+                  values: [null]
           - name: key2_0__val_2
             tests:
+              - not_null
               - accepted_values:
                   values: ['string']
           - name: key3__val
             tests:
+              - not_null
               - accepted_values:
                   values: ['-1234']
                   quote: true
           - name: key3__val_int
             tests:
+              - not_null
               - accepted_values:
                   values: [-1234]
                   quote: false

--- a/test_xdb/models/schema_tests/json_extract_path_text_test.yml
+++ b/test_xdb/models/schema_tests/json_extract_path_text_test.yml
@@ -1,0 +1,44 @@
+version: 2
+
+models:
+    - name: json_extract_path_text_test
+      description: "tests json_extract_path_text"
+      columns:
+          - name: key1__val
+            tests:
+              - accepted_values:
+                  values: ['value1']
+          - name: key2__val
+            tests:
+              - accepted_values:
+                  values: ['{"innerkey2_1":"innervalue2_1", "0":[0, null, "string"]}']
+          - name: key2_innerkey2_1__val
+            tests:
+              - accepted_values:
+                  values: ['innervalue2_1']
+          - name: key2_0__val
+            tests:
+              - accepted_values:
+                  values: ['[0, null, "string"]']
+          - name: key2_0__val_0
+            tests:
+              - accepted_values:
+                  values: ['0']
+          - name: key2_0__val_1
+            tests:
+              - accepted_values:
+                  values: ['']
+          - name: key2_0__val_2
+            tests:
+              - accepted_values:
+                  values: ['string']
+          - name: key3__val
+            tests:
+              - accepted_values:
+                  values: ['-1234']
+                  quote: true
+          - name: key3__val_int
+            tests:
+              - accepted_values:
+                  values: [-1234]
+                  quote: false

--- a/test_xdb/models/schema_tests/split_test.yml
+++ b/test_xdb/models/schema_tests/split_test.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+    - name: split_test
+      description: "test for split (str -> arr) function"
+      columns:
+          - name: spaces_str_len
+            tests:
+              - not_null
+              - accepted_values:
+                  values: [3]
+                  quote: false
+          - name: dashes_str_len
+            tests:
+              - not_null
+              - accepted_values:
+                  values: [3]
+                  quote: false
+          - name: spaces_col_len
+            tests:
+              - not_null
+              - accepted_values:
+                  values: [5]
+                  quote: false
+          - name: dashes_col_len
+            tests:
+              - not_null
+              - accepted_values:
+                  values: [5]
+                  quote: false

--- a/test_xdb/models/under_test/json_extract_path_text_test.sql
+++ b/test_xdb/models/under_test/json_extract_path_text_test.sql
@@ -1,0 +1,22 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+
+with test_json_data as (
+    select
+        {% set js = '{"key1":"value1", "key2":{"innerkey2_1":"innervalue2_1", "0":[0, null, "string"]}, "key3": -1234}' %}
+        {% if target.type == 'postgres' %}'{{js}}'::json
+        {% elif target.type == 'snowflake' %}parse_json('{{js}}')
+        {% endif %}
+            as json_col
+)
+select
+    json_col,
+    {{xdb.json_extract_path_text('json_col', ['key1'])}} as key1__val,
+    {{xdb.json_extract_path_text('json_col', ['key2'])}} as key2__val,
+    {{xdb.json_extract_path_text('json_col', ['key2', 'innerkey2_1'])}} as key2_innerkey2_1__val,
+    {{xdb.json_extract_path_text('json_col', ['key2', '0'])}} as key2_0__val,
+    {{xdb.json_extract_path_text('json_col', ['key2', '0', 0])}} as key2_0__val_0,
+    {{xdb.json_extract_path_text('json_col', ['key2', '0', 1])}} as key2_0__val_1,
+    {{xdb.json_extract_path_text('json_col', ['key2', '0', 2])}} as key2_0__val_2,
+    {{xdb.json_extract_path_text('json_col', ['key3'])}} as key3__val,
+    cast({{xdb.json_extract_path_text('json_col', ['key3'])}} as int) as key3__val_int
+from test_json_data

--- a/test_xdb/models/under_test/json_extract_path_text_test.sql
+++ b/test_xdb/models/under_test/json_extract_path_text_test.sql
@@ -11,9 +11,10 @@ with test_json_data as (
 select
     json_col,
     {{xdb.json_extract_path_text('json_col', ['key1'])}} as key1__val,
-    {{xdb.json_extract_path_text('json_col', ['key2'])}} as key2__val,
+    /* snowflake seems to reorder object keys, so straight query won't work */
+    length(replace({{xdb.json_extract_path_text('json_col', ['key2'])}}, ' ', '')) as key2__val,
     {{xdb.json_extract_path_text('json_col', ['key2', 'innerkey2_1'])}} as key2_innerkey2_1__val,
-    {{xdb.json_extract_path_text('json_col', ['key2', '0'])}} as key2_0__val,
+    replace({{xdb.json_extract_path_text('json_col', ['key2', '0'])}}, ' ', '') as key2_0__val,
     {{xdb.json_extract_path_text('json_col', ['key2', '0', 0])}} as key2_0__val_0,
     {{xdb.json_extract_path_text('json_col', ['key2', '0', 1])}} as key2_0__val_1,
     {{xdb.json_extract_path_text('json_col', ['key2', '0', 2])}} as key2_0__val_2,

--- a/test_xdb/models/under_test/split_test.sql
+++ b/test_xdb/models/under_test/split_test.sql
@@ -1,11 +1,12 @@
+/* TODO split is supported for bigquery. tests should support that */
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+
 {% if target.type == 'postgres' %}
     {% set arr_len_func = 'array_length' %}
     {% set arr_len_xarg = ',1' %}
 {% elif target.type == 'snowflake' %}
     {% set arr_len_func = 'array_size' %}
     {% set arr_len_xarg = '' %}
-{% else %}
-    {{raise_not_supported_error()}}
 {% endif %}
 
 with test_table as

--- a/test_xdb/models/under_test/split_test.sql
+++ b/test_xdb/models/under_test/split_test.sql
@@ -1,3 +1,22 @@
+{% if target.type == 'postgres' %}
+    {% set arr_len_func = 'array_length' %}
+    {% set arr_len_xarg = ',1' %}
+{% elif target.type == 'snowflake' %}
+    {% set arr_len_func = 'array_size' %}
+    {% set arr_len_xarg = '' %}
+{% else %}
+    {{raise_not_supported_error()}}
+{% endif %}
+
+with test_table as
+(
+    select
+        'string to split on spaces' as space_delim,
+        'string-to-split-on-dashes' as dash_delim
+)
 SELECT
-    {{xdb.split("word with spaces", " ")}} AS spaces
-    ,{{xdb.split("100-200-300", "-")}} AS dashes
+    {{arr_len_func}}({{xdb.split("'word with spaces'", " ")}}{{arr_len_xarg}}) AS spaces_str_len
+    ,{{arr_len_func}}({{xdb.split("'100-200-300'", "-")}}{{arr_len_xarg}}) AS dashes_str_len
+    ,{{arr_len_func}}({{xdb.split("space_delim", " ")}}{{arr_len_xarg}}) AS spaces_col_len
+    ,{{arr_len_func}}({{xdb.split("dash_delim", "-")}}{{arr_len_xarg}}) AS dashes_col_len
+from test_table


### PR DESCRIPTION
## What is this? 
Adds a new macro to essentially use `json_extract_path_text` across DBs.

## What changes in this PR? 
* added `xdb.json_extract_path_text` macro with snowflake and postgres support
* fixed failing `split` macro test

## PR Quality
- [ ] does `docker-compose exec testxdb test` run successfully? (snowflake and pg pass)
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 


@Health-Union/hu-data make sure to include a version tag in the merge commit!