### PR TITLE
UUID generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 RUN apt-get update -y && \
 apt-get install -y vim && \
-pip3 install dbt==0.19.0 && \ 
+pip3 install dbt==0.19.0 SQLAlchemy==1.3.22 && \
 mkdir /app && \
 mkdir /dbt-xdb 
 

--- a/macros/generate_uuid.sql
+++ b/macros/generate_uuid.sql
@@ -1,0 +1,24 @@
+{%- macro generate_uuid(type="v4") -%}
+  {#
+    Generates a uuid value of the given type. Only currently supports v4.
+
+    Prerequisite:
+      - Postgres requires the "uuid-ossp" extension to be added to the target database
+
+       ARGS:
+         - `type` (string) the type of uuid to generate (defaults to v4)
+
+       RETURNS: (varchar) The generated uuid value as a varchar
+  #}
+  {%- if type == "v4" -%}
+    {%- if target.type == 'postgres' -%}
+      (uuid_generate_v4()::text)
+    {%- elif target.type == 'snowflake' -%}
+      uuid_string()
+    {%- else -%}
+      {{ xdb.not_supported_exception('generate_uuid("v4")') }}
+    {%- endif -%}
+  {%- else -%}
+    {{ xdb.not_supported_exception('generate_uuid(' ~ type ~ ')')}}
+  {%- endif -%}
+{%- endmacro -%}

--- a/test_xdb/models/schema_tests/generate_uuid_test.yml
+++ b/test_xdb/models/schema_tests/generate_uuid_test.yml
@@ -1,0 +1,20 @@
+version: 2
+
+models:
+    - name: generate_uuid_test
+      description: "tests generate_uuid macro"
+      columns:
+          - name: uuid_varchar
+            tests:
+              - not_null
+          - name: uuid_length
+            tests:
+              - not_null
+              - accepted_values:
+                  values: [32]
+                  quote: false
+          - name: uuid_regex
+            tests:
+              - not_null
+              - accepted_values:
+                  values: ['00000000-0000-0000-0000-000000000000']

--- a/test_xdb/models/under_test/generate_uuid_test.sql
+++ b/test_xdb/models/under_test/generate_uuid_test.sql
@@ -1,0 +1,27 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+
+with uuids as (
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+    union all
+    select {{xdb.generate_uuid()}} as uuid_varchar
+)
+
+select
+    uuid_varchar,
+    length(replace(uuid_varchar, '-', '')) as uuid_length,
+    regexp_replace(uuid_varchar, '[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}', '00000000-0000-0000-0000-000000000000') as uuid_regex
+from uuids

--- a/test_xdb/scripts/gather_targets.py
+++ b/test_xdb/scripts/gather_targets.py
@@ -1,6 +1,10 @@
 import yaml
+from test_setup import prepare_postgres_db
 
 def gather_targets(specified_targets=list()):
     with open('./profiles.yml','r') as f:
         profile = yaml.safe_load(f.read())
+
+    if 'postgres' in specified_targets or len(specified_targets) == 0:
+        prepare_postgres_db(profile['default']['outputs']['postgres'])
     return specified_targets if specified_targets else profile['default']['outputs']

--- a/test_xdb/scripts/gather_targets.py
+++ b/test_xdb/scripts/gather_targets.py
@@ -5,6 +5,8 @@ def gather_targets(specified_targets=list()):
     with open('./profiles.yml','r') as f:
         profile = yaml.safe_load(f.read())
 
+    # handle any target specific setup that is needed (e.g. postgres extensions)
     if 'postgres' in specified_targets or len(specified_targets) == 0:
         prepare_postgres_db(profile['default']['outputs']['postgres'])
+
     return specified_targets if specified_targets else profile['default']['outputs']

--- a/test_xdb/scripts/test_setup.py
+++ b/test_xdb/scripts/test_setup.py
@@ -1,5 +1,6 @@
 import yaml
 import subprocess
+from sqlalchemy import create_engine
 
 with open('./profiles.yml','r') as f:
     profile = yaml.safe_load(f.read())
@@ -8,3 +9,13 @@ for target in profile['default']['outputs']:
     subprocess.call(['dbt','seed', '--profiles-dir','.','--target', target])
 
 
+def prepare_postgres_db(profile: dict):
+    user = profile['user']
+    password = profile['pass']
+    host = profile['host']
+    port = profile['port']
+    db = profile['dbname']
+    engine = create_engine(f"postgresql://{user}:{password}@{host}:{port}/{db}")
+    with engine.connect() as conn:
+        conn.execute('create extension if not exists "uuid-ossp"')
+    engine.dispose()

--- a/test_xdb/scripts/test_setup.py
+++ b/test_xdb/scripts/test_setup.py
@@ -10,6 +10,11 @@ for target in profile['default']['outputs']:
 
 
 def prepare_postgres_db(profile: dict):
+    """ Prepares the target postgres db for testing
+
+        Args:
+            - profile (dict): The loaded postgres yaml block from profiles.yml
+    """
     user = profile['user']
     password = profile['pass']
     host = profile['host']
@@ -17,5 +22,6 @@ def prepare_postgres_db(profile: dict):
     db = profile['dbname']
     engine = create_engine(f"postgresql://{user}:{password}@{host}:{port}/{db}")
     with engine.connect() as conn:
+        # install uuid-ossp for generating uuid fields
         conn.execute('create extension if not exists "uuid-ossp"')
     engine.dispose()


### PR DESCRIPTION
## What is this? 
Allows the generation of UUID (v4) values across different DBs

## What changes in this PR? 
* `generate_uuid` macro was added with support for snowflake and postgres
* updated test setup to add necessary extension (`uuid-ossp`) to postgres

## How does this impact our users?
* More cross database support is always better

## PR Quality
- [ ] does `docker-compose exec testxdb test` run successfully? (snowflake and postgres pass)
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 



@Health-Union/hu-data make sure to include a version tag in the merge commit!