### PR TITLE
Updated docs, docbuilder, and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ in your `packages.yml` add this line:
 ```
 (_no worries, this will be tagging very soon_. Right now we are committing new macros rapidly and don't want version hangups.)
 
+#### Database Prerequisites:
+
+To ensure compatibility, some database engines require extra setup to support certain `xdb` macros.
+
+- **Postgres**:
+  - `xdb.generate_uuid()` requires the `uuid-ossp` extension to be installed
 
 ### Using xdb
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -1,7 +1,7 @@
 
 # XDB Available Macros
 
-These macros carry functionality across **Snowflake**, **Postgresql**, **Redshift** and **BigQuery** unless otherwise noted. 
+These macros carry functionality across **Snowflake** and **Postgresql**, and most also support **BigQuery**. Individual support listed below.
 
 
 ### [_concat_cast_fields](../macros/concat.sql)
@@ -11,6 +11,8 @@ These macros carry functionality across **Snowflake**, **Postgresql**, **Redshif
 
 
 **Returns**: 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [_concat_separator_text](../macros/concat.sql)
 **xdb._concat_separator_text** (**separator** _None_)
 
@@ -18,16 +20,53 @@ These macros carry functionality across **Snowflake**, **Postgresql**, **Redshif
 
 
 **Returns**: 
+##### Supports: _All_
+----
+### [concat](../macros/concat.sql)
+**xdb.concat** (**fields** _list_, **separator** _string_, **convert_null** _None_)
+
+takes a list of column names to concatenate and an optional separator
+
+- fields one of field names to hash together
+- separator a string value to separate field values with. defaults to an empty space
+- null_representation defines how NULL values are passed to the target. Default is the string 'NULL'.
+
+**Returns**:      A string representing hash of given comments
+
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
+### [get_time_slice](../macros/get_time_slice.sql)
+**xdb.get_time_slice** (**date_or_time_expr** _date or time_, **slice_length** _int_, **date_or_time_part** _string_, **start_or_end** _string_)
+
+Calculates the beginning or end of a “slice” of time, 
+      where the length of the slice is a multiple of a standard unit of time (minute, hour, day, etc.).
+      This function can be used to calculate the start and end times of fixed-width “buckets” into which data can be categorized..
+
+- date_or_time_expr : This macro returns the start or end of the slice that contains this date or time.
+- slice_length : the width of the slice, i.e. how many units of time are contained in the slice. For example, if the unit is DAY and the slice_length is 2, then each slice is 2 days wide. The slice_length must be an integer greater than or equal to 1.
+- date_or_time_part : Time unit for the slice length. The value must be a string containing one of the values listed below:
+  - MINUTE, HOUR, DAY, YEAR
+  - NOTE: This macro has not been tested for second, week, month, or quarter intervals.
+- start_or_end : This is an optional constant parameter that determines whether the start or end of the slice should be returned.
+  - Supported values are ‘START’ or ‘END’. The values are case insensitive.
+  - The default value is ‘START’.
+
+**Returns**:         a timestamp
+
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [hash](../macros/hash.sql)
 **xdb.hash** (**fields** _list_)
 
-
+takes a list of values to hash, coerces them to strings and hashes them.
+        *Note* the fields will be sorted by name and concatenated as strings with a default '-' separator.
 
 - fields one of field names to hash together
 
 **Returns**:          A string representing hash of `fields`
-    */
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [last_value](../macros/last_value.sql)
 **xdb.last_value** (**col** _string_, **data_type** _string_, **partition_by** _string_, **order_by** _string_)
 
@@ -39,8 +78,9 @@ Window function that returns the last value within an ordered group of values.
 - order_by : the expression to order the partitioned data by, e.g. "date DESC"
 
 **Returns**:        The last value within an ordered group of values.
-  
 
+##### Supports: _Postgres, Snowflake_
+----
 ### [linear_interpolate](../macros/linear_interpolate.sql)
 **xdb.linear_interpolate** (**x_i** _numeric_, **x_0** _numeric_, **y_0** _numeric_, **x_1** _numeric_, **y_1** _numeric_)
 
@@ -53,8 +93,9 @@ Calculates linearly interpolated value given two data points
 - y_1 : y value of second data point
 
 **Returns**:        linearly interpolated value (numeric)
-  
 
+##### Supports: _All (purely arithmetic)_
+----
 ### [regexp_replace](../macros/regexp.sql)
 **xdb.regexp_replace** (**val** _string/column_, **pattern** _string_, **replace** _string_)
 
@@ -67,6 +108,8 @@ Calculates linearly interpolated value given two data points
 **Returns**:      the updated string. 
   */
 
+##### Supports: __
+----
 ### [timestamp_to_date_part](../macros/timestamp_to_date_part.sql)
 **xdb.timestamp_to_date_part** (**timestamp_t** _timestamp_, **date_part** _string_)
 
@@ -76,28 +119,31 @@ Ensures that result of EXTRACT in Snowflake is a double to match the default beh
 - date_part : tested for 'epoch', 'year', 'month', 'day', 'hour', 'minute', 'second'
 
 **Returns**:        double 
-  
 
+##### Supports: _Postgres, Snowflake_
+----
 ### [_fold](../macros/fold.sql)
 **xdb._fold** (**val** _string_)
 
-
+folds a value per the target adapter default.
 
 - val : the value to be folded.
 
 **Returns**:      `val` either upper or lowercase (or unfolded), per the target adapter spec.
-   */
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [_not_supported_exception](../macros/not_supported_exception.sql)
 **xdb._not_supported_exception** (**_name** _None_)
 
-
+Throws an exception unless the global `xdb_allow_unsupported_macros` isTrue.
 
 - macro_name : the name of the macro throwing the exception.
 
 **Returns**:          None
-    */
 
+##### Supports: _All_
+----
 ### [_regex_string_escape](../macros/regexp.sql)
 **xdb._regex_string_escape** (**pattern** _string_)
 
@@ -106,8 +152,9 @@ applies the weird escape sequences required for bigquery and snowflake
 - pattern the regex pattern to be escaped
 
 **Returns**:         A properly escaped regex string
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [aggregate_strings](../macros/aggregate_strings.sql)
 **xdb.aggregate_strings** (**val** _None_, **delim** _None_)
 
@@ -115,6 +162,8 @@ applies the weird escape sequences required for bigquery and snowflake
 
 
 **Returns**: 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [any_value](../macros/any_value.sql)
 **xdb.any_value** (**val** _None_)
 
@@ -122,16 +171,20 @@ applies the weird escape sequences required for bigquery and snowflake
 
 
 **Returns**: 
+##### Supports: _Postgres, Snowflake, BigQuery, Redshift_
+----
 ### [array_index](../macros/array_index.sql)
 **xdb.array_index** (**index** _None_)
 
-
+This macro takes a number and adjusts the index based on programming language. We use 0
+        index because we're rational human beings
 
 - Index the 0 based index to convert
 
-**Returns**:      The right position for the right database
-    */
+**Returns**:          The right position for the right database
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [cast_timestamp](../macros/cast_timestamp.sql)
 **xdb.cast_timestamp** (**val** _identifier/date/timestamp_, **cast_as** _string_)
 
@@ -141,8 +194,9 @@ converts `val` to either a timestamp with timezone or a timestamp without timezo
 - cast_as the destination data type, supported are `timestamp_tz` and `timestamp(_ntz)`
 
 **Returns**:         The value typed as either timestamp or timestamp_ntz **with UTC time zone**
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [dateadd](../macros/dateadd.sql)
 **xdb.dateadd** (**part** _string_, **amount_to_add** _int_, **value** _string_)
 
@@ -154,8 +208,9 @@ adds `amount_to_add` `part`s to `value`. so adding one day to Jan 1 2020 would b
 - value the date string or column to add to.
 
 **Returns**:         a date value with the amount added.
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [datediff](../macros/datediff.sql)
 **xdb.datediff** (**part** _string_, **left_val** _date/timestamp_, **right_val** _date/timestamp_, **date_format** _pattern_)
 
@@ -168,8 +223,9 @@ determines the delta (in `part` units) between first_val and second_val.
 - date_format a string pattern for the provided arguments (primarily for BigQuery)
 
 **Returns**:         An integer representing the delta in `part` units
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [fold](../macros/fold.sql)
 **xdb.fold** (**val** _None_)
 
@@ -177,6 +233,22 @@ determines the delta (in `part` units) between first_val and second_val.
 
 
 **Returns**: 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
+### [generate_daily_time_series_from](../macros/generate_daily_time_series_from.sql)
+**xdb.generate_daily_time_series_from** (**start_date** _date_, **stop_date** _date_)
+
+Used in conjunction with generate_time_series_values, this macro returns a time series
+        of values based on the start_date and stop_date in 1 day increments
+
+- start_date the start date of the series
+- stop_date the ending date of the series
+  - 
+
+**Returns**:         A new column containing the generated series.
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [generate_daily_time_series_values](../macros/generate_daily_time_series_values.sql)
 **xdb.generate_daily_time_series_values** (**start_date** _date_, **stop_date** _date_)
 
@@ -187,8 +259,23 @@ Used in conjunction with generate_daily_time_series_from, this macro returns a t
 - stop_date the ending date of the series
 
 **Returns**:         A new column containing the generated series.
-    
 
+##### Supports: _Postgres, Snowflake_
+----
+### [generate_uuid](../macros/generate_uuid.sql)
+**xdb.generate_uuid** (**type** _None_)
+
+Generates a uuid value of the given type. Only currently supports v4.
+
+    Prerequisite:
+      - Postgres requires the "uuid-ossp" extension to be added to the target database
+
+- `type` the type of uuid to generate (defaults to `"v4"`)
+
+**Returns**:         (varchar) The generated uuid value as a varchar
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [interval_to_timestamp](../macros/interval_to_timestamp.sql)
 **xdb.interval_to_timestamp** (**part** _string_, **val** _integer representing a unit of time_)
 
@@ -199,15 +286,37 @@ converts and interval `val` to a timestamp
 - val the value
 
 **Returns**:         A string representing the time in HH24:MM:SS format
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
+### [json_extract_path_text](../macros/json_extract_path_text.sql)
+**xdb.json_extract_path_text** (**column** _None_, **path_vals** _None_)
+
+Extracts the value at `path_vals` from the json typed `column` (or expression)
+
+    Note that in some DBs, the context is used for extraction:
+      - Postgres: `'0'` will indicate the key `"0"` or `[0]` (first array item) based on the object it is requested of.
+
+- `column` the column name (or expression) to extract the values from
+- `path_vals` the path to the desired value.
+  - The list can be a combination of strings and integers. In general, integers will be treated as json array indexing unless they are typed as strings (e.g. `'0'` instead of `0`)
+  - 
+
+**Returns**:         (varchar) The value as a string at the given path in the json or `NULL` if the path does not exist
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [not_supported_exception](../macros/not_supported_exception.sql)
 **xdb.not_supported_exception** (**_name** _None_)
 
+Wraps `_not_supported_exception` macro
 
+- macro_name : the name of the macro throwing the exception.
 
+**Returns**:          None
 
-**Returns**: 
+##### Supports: _All_
+----
 ### [quote_insensitive](../macros/quote_insensitive.sql)
 **xdb.quote_insensitive** (**identifier** _string_)
 
@@ -217,8 +326,20 @@ Correctly quotes identifers to match the native folding for the target data ware
 - identifier the column / database / relation name to be folded and quoted.
 
 **Returns**:         The `identifier` value correctly folded **and wrapped in double quotes**.
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
+### [recursive_cte](../macros/recursive_cte.sql)
+**xdb.recursive_cte** (**** _None_)
+
+Supplies the correct wrapper for recursive CTEs in postgres & snowflake
+       NOTE: Bigquery does not currently support recursive CTEs per their docs
+
+
+**Returns**:         The correct wrapper for the CTE
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [regexp](../macros/regexp.sql)
 **xdb.regexp** (**val** _None_, **pattern** _None_, **flag** _None_)
 
@@ -226,6 +347,8 @@ Correctly quotes identifers to match the native folding for the target data ware
 
 
 **Returns**: 
+##### Supports: __
+----
 ### [regexp_count](../macros/regexp.sql)
 **xdb.regexp_count** (**value** _string_, **pattern** _string_)
 
@@ -237,6 +360,8 @@ counts how many instances of `pattern` in `value`
 **Returns**:         An integer count of patterns in value
     
 
+##### Supports: __
+----
 ### [split](../macros/split.sql)
 **xdb.split** (**_column** _None_, **delimeter** _string_)
 
@@ -246,8 +371,9 @@ Splits the supplied string into an array based on the delimiter
 - delimeter the delimeter to use when splitting the split_column
 
 **Returns**:         An array of the split string
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [split_to_table](../macros/split_to_table.sql)
 **xdb.split_to_table** (**split_column** _string_, **delimeter** _string_)
 
@@ -257,8 +383,9 @@ Splits the supplied string type column into rows based on the delimeter
 - delimeter the delimeter to use when splitting the split_column
 
 **Returns**:         A new column containing the split data.
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [split_to_table_values](../macros/split_to_table_values.sql)
 **xdb.split_to_table_values** (**table_array** _string_)
 
@@ -269,22 +396,27 @@ Used in conjunction with split_to_table, this macro returns the split_to_table
 - table_array the table array form of the split_column.
 
 **Returns**:         A new column containing the split data.
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [strip_to_single_line](../macros/strip_to_single_line.sql)
 **xdb.strip_to_single_line** (**str** _None_)
 
-
+this removes all side-effect formatting from nested macros, producing a single line sql statement
 
 
 **Returns**: 
+##### Supports: _All_
+----
 ### [test_does_not_contain](../macros/test_does_not_contain.sql)
 **xdb.test_does_not_contain** (**model** _None_, **substring** _None_, **column_name** _None_)
 
-
+tests that `substring` is not contained in `column_name`
 
 
 **Returns**: 
+##### Supports: _Most (requires basic CTE support)_
+----
 ### [timeadd](../macros/timeadd.sql)
 **xdb.timeadd** (**part** _string_, **amount_to_add** _int_, **value** _string_)
 
@@ -296,8 +428,9 @@ adds `amount_to_add` `part`s to `value`. so adding one hour to Jan 1 2020 01:00:
 - value the date time string or column to add to.
 
 **Returns**:         a date time value with the amount added.
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [unnest](../macros/unnest.sql)
 **xdb.unnest** (**array_to_** _None_)
 
@@ -306,8 +439,9 @@ Takes an array and splits it into rows of values
 - array_to_unnest the array to unnest.
 
 **Returns**:         A new column containing the split data.
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [unnest_values](../macros/unnest_values.sql)
 **xdb.unnest_values** (**table_array** _string_)
 
@@ -317,8 +451,9 @@ Used in conjunction with unnest, this macro returns the unnested
 - table_array the table array form of the split_column.
 
 **Returns**:         A new column containing the split data.
-    
 
+##### Supports: _Postgres, Snowflake, BigQuery_
+----
 ### [using](../macros/using.sql)
 **xdb.using** (**rel_1** _None_, **rel_2** _None_, **col** _None_)
 
@@ -326,3 +461,5 @@ Used in conjunction with unnest, this macro returns the unnested
 
 
 **Returns**: 
+##### Supports: _Postgres, Snowflake, BigQuery, Redshift_
+----

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -99,16 +99,16 @@ Calculates linearly interpolated value given two data points
 ### [regexp_replace](../macros/regexp.sql)
 **xdb.regexp_replace** (**val** _string/column_, **pattern** _string_, **replace** _string_)
 
-
+replaces any matches of `pattern` in `val` with `replace`.
+    NOTE: this will use native (database) regex matching, which may differ from db to db.
 
 - val the value to search for `pattern`.
 - pattern the native regex pattern to search for.
 - replace the string to insert in place of `pattern`.
 
 **Returns**:      the updated string. 
-  */
 
-##### Supports: __
+##### Supports: _Postgres, Snowflake, BigQuery_
 ----
 ### [timestamp_to_date_part](../macros/timestamp_to_date_part.sql)
 **xdb.timestamp_to_date_part** (**timestamp_t** _timestamp_, **date_part** _string_)
@@ -347,7 +347,7 @@ Supplies the correct wrapper for recursive CTEs in postgres & snowflake
 
 
 **Returns**: 
-##### Supports: __
+##### Supports: _Postgres, Snowflake, BigQuery_
 ----
 ### [regexp_count](../macros/regexp.sql)
 **xdb.regexp_count** (**value** _string_, **pattern** _string_)
@@ -358,9 +358,8 @@ counts how many instances of `pattern` in `value`
 - pattern the regex pattern to search for
 
 **Returns**:         An integer count of patterns in value
-    
 
-##### Supports: __
+##### Supports: _Postgres, Snowflake, BigQuery_
 ----
 ### [split](../macros/split.sql)
 **xdb.split** (**_column** _None_, **delimeter** _string_)

--- a/macros/aggregate_strings.sql
+++ b/macros/aggregate_strings.sql
@@ -1,4 +1,10 @@
 {%- macro aggregate_strings(val, delim) -%}
+    {#
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+    #}
     {%- if target.type ==  'postgres' -%} 
         string_agg({{ val }}::varchar {{',' if delim else ''}}  {{ delim }})
     {%- elif target.type == 'bigquery' -%}

--- a/macros/any_value.sql
+++ b/macros/any_value.sql
@@ -1,4 +1,11 @@
 {%- macro any_value(val) -%}
+    {#
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+            - Redshift
+    #}
     {%- if target.type in ('postgres','redshift',) -%} 
 	max('{{val}}') 
     {%- elif target.type in ('snowflake','bigquery',) -%}

--- a/macros/array_index.sql
+++ b/macros/array_index.sql
@@ -1,10 +1,14 @@
 {%- macro array_index(index) -%}
-  /*{# This macro takes a number and adjusts the index based on programming language. We use 0
+    {# This macro takes a number and adjusts the index based on programming language. We use 0
         index because we're rational human beings
-    ARGS:
-        - Index (int) the 0 based index to convert
-    RETURNS: The right position for the right database
-    #}*/
+        ARGS:
+            - Index (int) the 0 based index to convert
+        RETURNS: The right position for the right database
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+    #}
 
     {%- if target.type == 'postgres' -%} 
 	{{ (index + 1) }}

--- a/macros/cast_timestamp.sql
+++ b/macros/cast_timestamp.sql
@@ -4,6 +4,10 @@
          - val (identifier/date/timestamp) the value to be cast.  
          - cast_as (string) the destination data type, supported are `timestamp_tz` and `timestamp(_ntz)`
        RETURNS: The value typed as either timestamp or timestamp_ntz **with UTC time zone**
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- set cast_as = cast_as |lower -%}
     {%if cast_as not in ('timestamp','timestamp_ntz','timestamp_tz',) %}

--- a/macros/concat.sql
+++ b/macros/concat.sql
@@ -1,11 +1,15 @@
 {% macro concat(fields, separator='', convert_null=true) -%}
-  /*{# takes a list of column names to concatenate and an optional separator
+    {# takes a list of column names to concatenate and an optional separator
     ARGS:
         - fields (list) one of field names to hash together
-        - separator a string value to separate field values with. defaults to an empty space
+        - separator (string) a string value to separate field values with. defaults to an empty space
         - null_representation (string) defines how NULL values are passed to the target. Default is the string 'NULL'. 
     RETURNS: A string representing hash of given comments
-    #}*/
+    SUPPORTS:
+        - Postgres
+        - Snowflake
+        - BigQuery
+    #}
 
     {%- set sep_text = xdb._concat_separator_text(separator) -%}
     {%- set casted_fields = xdb._concat_cast_fields(fields, convert_null) -%}
@@ -20,10 +24,20 @@
 {%- endmacro %}
 
 {% macro _concat_separator_text(separator) -%}
+    {#
+        SUPPORTS:
+            - All
+    #}
     , {{ "'" ~ separator ~ "', " if separator != '' }}
 {%- endmacro %}
 
 {% macro _concat_cast_fields(fields, convert_null) -%}
+    {#
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+    #}
     {%- set casted_fields = [] -%}
     {%- for field in fields -%}
         {%- if target.type in ('postgres','snowflake',)  -%}

--- a/macros/dateadd.sql
+++ b/macros/dateadd.sql
@@ -6,6 +6,10 @@
          - amount_to_add (int) number of `part` units to add to `value`. Negative subtracts.
          - value (string) the date string or column to add to.
        RETURNS: a date value with the amount added.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- set part = part |lower -%}
     {%if part not in ('day','week','month','year',) %}

--- a/macros/datediff.sql
+++ b/macros/datediff.sql
@@ -7,6 +7,10 @@
          - right_val (date/timestamp) the value after the minus in the equation "left - right"
          - date_format (pattern) a string pattern for the provided arguments (primarily for BigQuery)
        RETURNS: An integer representing the delta in `part` units
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- set part = part |lower -%}
     {%if part not in ('second', 'minute', 'hour', 'day','week','month','year','quarter',) %}

--- a/macros/fold.sql
+++ b/macros/fold.sql
@@ -1,15 +1,25 @@
 
 {%- macro fold(val) -%}
+    {#
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+    #}
    {{ xdb.strip_to_single_line(xdb._fold(val)) }}
 {%- endmacro -%}
 
 
 {%- macro _fold(val) -%}
-    /*{# folds a value per the target adapter default.
+    {# folds a value per the target adapter default.
     ARGS:
       - val(string): the value to be folded.
     RETURNS: `val` either upper or lowercase (or unfolded), per the target adapter spec.
-   #}*/
+    SUPPORTS:
+        - Postgres
+        - Snowflake
+        - BigQuery
+    #}
     {%- if target.type == 'postgres' -%}
         {{ val | lower }} 
     {%- elif target.type == 'snowflake' -%}

--- a/macros/generate_daily_time_series_from.sql
+++ b/macros/generate_daily_time_series_from.sql
@@ -6,6 +6,9 @@
          - stop_date (date) the ending date of the series
 
        RETURNS: A new column containing the generated series.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
     #}
 
     {%- if target.type in ['postgres'] -%} 

--- a/macros/generate_daily_time_series_values.sql
+++ b/macros/generate_daily_time_series_values.sql
@@ -5,6 +5,9 @@
          - start_date (date) the start date of the series
          - stop_date (date) the ending date of the series
        RETURNS: A new column containing the generated series.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
     #}
 
     {%- if target.type in ['postgres'] -%} 

--- a/macros/generate_uuid.sql
+++ b/macros/generate_uuid.sql
@@ -6,9 +6,11 @@
       - Postgres requires the "uuid-ossp" extension to be added to the target database
 
        ARGS:
-         - `type` (string) the type of uuid to generate (defaults to v4)
-
+         - `type` (string) the type of uuid to generate (defaults to `"v4"`)
        RETURNS: (varchar) The generated uuid value as a varchar
+       SUPPORTS:
+            - Postgres
+            - Snowflake
   #}
   {%- if type == "v4" -%}
     {%- if target.type == 'postgres' -%}

--- a/macros/get_time_slice.sql
+++ b/macros/get_time_slice.sql
@@ -6,12 +6,16 @@
          - date_or_time_expr (date or time): This macro returns the start or end of the slice that contains this date or time.
          - slice_length (int): the width of the slice, i.e. how many units of time are contained in the slice. For example, if the unit is DAY and the slice_length is 2, then each slice is 2 days wide. The slice_length must be an integer greater than or equal to 1.
          - date_or_time_part (string): Time unit for the slice length. The value must be a string containing one of the values listed below:
-            - MINUTE, HOUR, DAY, YEAR
-            - NOTE: This macro has not been tested for second, week, month, or quarter intervals.
+            MINUTE, HOUR, DAY, YEAR
+            NOTE: This macro has not been tested for second, week, month, or quarter intervals.
          - start_or_end (string): This is an optional constant parameter that determines whether the start or end of the slice should be returned.
-            Supported values are ‘START’ or ‘END’. The values are case-insensitive.
+            Supported values are ‘START’ or ‘END’. The values are case insensitive.
             The default value is ‘START’.
-       RETURN: a timestamp
+       RETURNS: a timestamp
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
   {%- if target.type == 'postgres' -%}
     CASE 

--- a/macros/hash.sql
+++ b/macros/hash.sql
@@ -1,10 +1,14 @@
 {% macro hash(fields) -%}
-    /*{# takes a list of values to hash, coerces them to strings and hashes them.
+    {# takes a list of values to hash, coerces them to strings and hashes them.
         *Note* the fields will be sorted by name and concatenated as strings with a default '-' separator.
         ARGS:
             - fields (list) one of field names to hash together
         RETURNS: A string representing hash of `fields`
-    #}*/
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+    #}
     {%- set separator = '-' -%}
     {%- set fields = fields | sort() -%}
     {%- if target.type == 'postgres'  -%}

--- a/macros/interval_to_timestamp.sql
+++ b/macros/interval_to_timestamp.sql
@@ -5,6 +5,10 @@
          - part (string) one of 'second', 'minute'
          - val (integer representing a unit of time) the value 
        RETURNS: A string representing the time in HH24:MM:SS format
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- set part = part |lower -%}
     {%if part not in ('second', 'minute',) %}

--- a/macros/json_extract_path_text.sql
+++ b/macros/json_extract_path_text.sql
@@ -1,17 +1,18 @@
 {%- macro json_extract_path_text(column, path_vals) -%}
   {#
     Extracts the value at `path_vals` from the json typed `column` (or expression)
+
+    Note that in some DBs, the context is used for extraction:
+      - Postgres: `'0'` will indicate the key `"0"` or `[0]` (first array item) based on the object it is requested of.
        ARGS:
          - `column` (string) the column name (or expression) to extract the values from
          - `path_vals` (list[string/int]) the path to the desired value. 
-           Strings values are assumed to be keys
-           Integer values are assumed to index arrays
-           Integers that are typed as strings are assumed to be keys
+           The list can be a combination of strings and integers. In general, integers will be treated as json array indexing unless they are typed as strings (e.g. `'0'` instead of `0`)
 
-           Note that in some DB cases it does not matter the typing:
-            - postgres: '0' will indicate the key "0" or first array item based on context
-
-       RETURNS: (varchar) The value at the given path in the column value
+       RETURNS: (varchar) The value as a string at the given path in the json or `NULL` if the path does not exist
+       SUPPORTS:
+            - Postgres
+            - Snowflake
   #}
   {%- if target.type == 'postgres' -%}
     {%- set expr = namespace(value="json_extract_path_text(" ~ column ~ ", ") -%}

--- a/macros/last_value.sql
+++ b/macros/last_value.sql
@@ -6,6 +6,9 @@
         - partition_by (string): the expression to be partitioned by, e.g. "id, type"
         - order_by (string): the expression to order the partitioned data by, e.g. "date DESC"
       RETURNS: The last value within an ordered group of values.
+      SUPPORTS:
+            - Postgres
+            - Snowflake
   #}
   {%- if target.type == 'postgres' -%}
     last_value({{ col }}::{{ data_type }}) 

--- a/macros/linear_interpolate.sql
+++ b/macros/linear_interpolate.sql
@@ -7,6 +7,8 @@
         - x_1 (numeric): x value of second data point
         - y_1 (numeric): y value of second data point
       RETURNS: linearly interpolated value (numeric)
+      SUPPORTS:
+            - All (purely arithmetic)
   #}
   (({{y_1}} - {{y_0}}) / ({{x_1}} - {{x_0}})) * ({{x_i}} - {{x_0}}) + {{y_0}}
 {% endmacro %}

--- a/macros/quote_insensitive.sql
+++ b/macros/quote_insensitive.sql
@@ -4,6 +4,10 @@
        ARGS:
          - identifier (string) the column / database / relation name to be folded and quoted.
        RETURNS: The `identifier` value correctly folded **and wrapped in double quotes**.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- if target.type ==  'postgres' -%} 
         "{{identifier|lower}}"

--- a/macros/recursive_cte.sql
+++ b/macros/recursive_cte.sql
@@ -1,9 +1,10 @@
 {%- macro recursive_cte() -%}
     {# Supplies the correct wrapper for recursive CTEs in postgres & snowflake
        NOTE: Bigquery does not currently support recursive CTEs per their docs
-       ARGS:
-         - none
        RETURNS: The correct wrapper for the CTE
+       SUPPORTS:
+            - Postgres
+            - Snowflake
     #}
     {%- if target.type ==  'postgres' -%} 
         WITH RECURSIVE 

--- a/macros/regexp.sql
+++ b/macros/regexp.sql
@@ -21,6 +21,12 @@
 {%- endmacro -%}
 
 {%- macro regexp(val,pattern,flag) -%}
+    {#
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+    #}
     {%- if target.type in ('postgres','redshift',) -%} 
 	'{{val}}' {{'~*' if flag == 'i' else '~'}} '{{xdb._regex_string_escape(pattern)}}'
     {%- elif target.type == 'snowflake' -%}
@@ -39,6 +45,10 @@
          - value (string) the subject to be searched
          - pattern (string) the regex pattern to search for
        RETURNS: An integer count of patterns in value
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- set pattern = xdb._regex_string_escape(pattern) -%}
     {%- if target.type ==  'postgres' -%} 
@@ -54,14 +64,18 @@
 
 
 {% macro regexp_replace(val, pattern, replace) %}
-  /*{# replaces any matches of `pattern` in `val` with `replace`.
+  {# replaces any matches of `pattern` in `val` with `replace`.
     NOTE: this will use native (database) regex matching, which may differ from db to db.
     ARGS:
         - val (string/column) the value to search for `pattern`.
         - pattern (string) the native regex pattern to search for.
         - replace (string) the string to insert in place of `pattern`. 
     RETURNS: the updated string. 
-  #}*/
+    SUPPORTS:
+        - Postgres
+        - Snowflake
+        - BigQuery
+  #}
   {%- set pattern = xdb._regex_string_escape(pattern) -%}
   {%- if target.type in ('postgres','snowflake',) -%}
     regexp_replace( {{ val }}, {{ pattern }}, {{ replace }})

--- a/macros/regexp.sql
+++ b/macros/regexp.sql
@@ -3,6 +3,10 @@
        ARGS:
          - pattern (string) the regex pattern to be escaped
        RETURNS: A properly escaped regex string
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- if target.type == 'postgres'  -%} 
         {{pattern}}

--- a/macros/split.sql
+++ b/macros/split.sql
@@ -5,6 +5,10 @@
          - split_column (string) the column / database / relation name to be split.
          - delimeter (string) the delimeter to use when splitting the split_column
        RETURNS: An array of the split string
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- if target.type ==  'postgres' -%} 
         string_to_array({{ split_column }}, '{{ delimeter }}' )

--- a/macros/split_to_table.sql
+++ b/macros/split_to_table.sql
@@ -4,6 +4,10 @@
          - split_column (string) the column / database / relation name to be split.
          - delimeter (string) the delimeter to use when splitting the split_column
        RETURNS: A new column containing the split data.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- if target.type in ['postgres', 'bigquery', 'snowflake'] -%} 
         {{ xdb.unnest(xdb.split(split_column, delimeter )) }}

--- a/macros/split_to_table_values.sql
+++ b/macros/split_to_table_values.sql
@@ -5,6 +5,10 @@
     ARGS:
          - table_array (string) the table array form of the split_column.
        RETURNS: A new column containing the split data.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- if target.type in ['postgres', 'bigquery', 'snowflake'] -%} 
         {{ xdb.unnest_values(table_array) }}

--- a/macros/timeadd.sql
+++ b/macros/timeadd.sql
@@ -6,6 +6,10 @@
          - amount_to_add (int) number of `part` units to add to `value`. Negative subtracts.
          - value (string) the date time string or column to add to.
        RETURNS: a date time value with the amount added.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- set part = part |lower -%}
     {%if part not in ('second','minute','hour') %}

--- a/macros/timestamp_to_date_part.sql
+++ b/macros/timestamp_to_date_part.sql
@@ -4,6 +4,9 @@
         - timestamp_t (timestamp): timestamp to extract the date_part from 
         - date_part (string): tested for 'epoch', 'year', 'month', 'day', 'hour', 'minute', 'second'
       RETURNS: double 
+      SUPPORTS:
+            - Postgres
+            - Snowflake
   #}
   {%- if target.type == 'postgres' -%}
     EXTRACT({{ date_part }} from {{ timestamp_t }})

--- a/macros/unnest.sql
+++ b/macros/unnest.sql
@@ -4,6 +4,10 @@
        ARGS:
          - array_to_unnest (string) the array to unnest.
        RETURNS: A new column containing the split data.
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- if target.type in ['postgres', 'bigquery'] -%} 
         unnest({{ array_to_unnest }})

--- a/macros/unnest_values.sql
+++ b/macros/unnest_values.sql
@@ -5,6 +5,10 @@
        ARGS:
          - table_array (string) the table array form of the split_column.
        RETURNS: A new column containing the split data.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
     #}
     {%- if target.type in ['postgres', 'bigquery'] -%} 
         {{ table_array }}

--- a/macros/using.sql
+++ b/macros/using.sql
@@ -1,4 +1,11 @@
 {%- macro using(rel_1,rel_2,col) -%}
+    {#
+        SUPPORTS:
+            - Postgres
+            - Snowflake
+            - BigQuery
+            - Redshift
+    #}
     {%- if target.type in ('postgres','redshift','bigquery','snowflake',) -%} 
 	    {{rel_1}} JOIN {{rel_2}} USING ({{col}})
     {%- else -%}

--- a/macros/utilities/not_supported_exception.sql
+++ b/macros/utilities/not_supported_exception.sql
@@ -1,9 +1,11 @@
 {%- macro _not_supported_exception(macro_name) -%} {# no_coverage #}
-    /*{# Throws an exception unless the global `xdb_allow_unsupported_macros` isTrue.
+    {# Throws an exception unless the global `xdb_allow_unsupported_macros` isTrue.
         ARGS:
          - macro_name (string): the name of the macro throwing the exception.
         RETURNS: None
-    #}*/
+        SUPPORTS:
+            - All
+    #}
     {%- if not var("xdb_allow_unsupported_macros", False) -%}
 	    {{exceptions.raise_compiler_error("macro " ~ macro_name ~ " is not supported for target " ~ target.type ~ ".")}}
     {%- else -%}
@@ -12,5 +14,12 @@
 {%- endmacro -%}  
 
 {%- macro not_supported_exception(macro_name) -%} {# no_coverage #}
+    {# Wraps `_not_supported_exception` macro
+        ARGS:
+         - macro_name (string): the name of the macro throwing the exception.
+        RETURNS: None
+        SUPPORTS:
+            - All
+    #}
     {{xdb.strip_to_single_line(xdb._not_supported_exception(macro_name))}}
 {%- endmacro -%}

--- a/macros/utilities/strip_to_single_line.sql
+++ b/macros/utilities/strip_to_single_line.sql
@@ -1,4 +1,7 @@
-{# this removes all side-effect formatting from nested macros, producing a single line sql statement #}
 {%- macro strip_to_single_line(str) -%}
+    {# this removes all side-effect formatting from nested macros, producing a single line sql statement
+        SUPPORTS:
+            - All
+    #}
     {{ str | replace('/*',' ') | replace('*/',' ') | replace('\n',' ') }}
 {%- endmacro -%}

--- a/macros/utilities/tests/test_does_not_contain.sql
+++ b/macros/utilities/tests/test_does_not_contain.sql
@@ -1,5 +1,8 @@
 {%- macro test_does_not_contain(model, substring, column_name) -%}
-    /*{# tests that `substring` is not contained in `column_name` #}*/
+    {# tests that `substring` is not contained in `column_name`
+        SUPPORTS:
+            - Most (requires basic CTE support)
+    #}
     WITH instances AS (
         SELECT 
             1 AS instance

--- a/test_xdb/scripts/build_docs.py
+++ b/test_xdb/scripts/build_docs.py
@@ -4,7 +4,7 @@ from macrodocs import macrodocs
 header = """
 # XDB Available Macros
 
-These macros carry functionality across **Snowflake**, **Postgresql**, **Redshift** and **BigQuery** unless otherwise noted. 
+These macros carry functionality across **Snowflake** and **Postgresql**, and most also support **BigQuery**. Individual support listed below.
 
 """
 macrodocs('/dbt-xdb/macros',

--- a/test_xdb/scripts/macrodocs.py
+++ b/test_xdb/scripts/macrodocs.py
@@ -12,6 +12,7 @@ def macrodocs(macros_folder, docs_file, header_text, prefix=None):
     comments_end = re.compile(r'.*#}')
     args_start = re.compile(r'(?i)^\s*ARGS:\s*$')
     return_start = re.compile(r'(?i)^\s*RETURNS:')
+    support_start = re.compile(r'(?i)^\s*SUPPORTS:')
     macro_end = re.compile(r'{%(-)?\s+endmacro\s+(-)?%}')
     for root, dirs, files in os.walk(macros_folder):
         for name in filter(lambda x: x.endswith('.sql'), files):
@@ -44,29 +45,38 @@ def macrodocs(macros_folder, docs_file, header_text, prefix=None):
             description,returns = '',''
             args=list()    
             arg_types = dict()
-            in_docs,in_description,in_args,in_return= False,False,False,False
+            supports = list()
+            in_docs,in_description,in_args,in_return,in_support = False,False,False,False,False
             for line in macro[1:-1]:
                 if re.match(comments_start,line):
                     in_docs, in_description = True,True
 
                 if re.match(return_start,line):
-                    in_return,in_args,in_description = True,False,False
+                    in_return,in_args,in_description,in_support = True,False,False,False
                 if re.match(args_start,line):
-                    in_return,in_args,in_description = False,True,False
-                
+                    in_return,in_args,in_description,in_support = False,True,False,False
+                if re.match(support_start,line):
+                    in_return,in_args,in_description,in_support = False,False,False,True
 
                 if in_description:
                     description += line.replace('{#','').replace('#}','')
 
                 if in_args:
                     if 'ARGS:' not in line.upper():
-                        types=line[line.index('(')+1 : line.index(')')]
-                        key=line[line.index('-')+1:line.index('(')].strip()
-                        arg_types[key]=types
-                        args.append(line)
+                        if line.count('-') > 0:
+                            types=line[line.index('(')+1 : line.index(')')]
+                            key=line[line.index('-')+1:line.index('(')].strip()
+                            arg_types[key]=types
+                        args.append(line.strip())
                 
                 if in_return:
                     returns += line.replace('RETURNS:','').replace('returns:','').replace('{#','').replace('#}','')
+
+                if in_support:
+                    support_line = line.replace('{#','').replace('#}','').strip()
+                    if 'SUPPORTS:' not in support_line.upper() and support_line.count('-') > 0:
+                        val=support_line[support_line.index('-')+1:].strip()
+                        supports.append(val)
 
                 if re.match(comments_end,line):
                     break
@@ -80,12 +90,19 @@ def macrodocs(macros_folder, docs_file, header_text, prefix=None):
                 md.write(f'{arg_string[:-2]})\n')    
                 md.write('\n'+description.strip() +'\n')
                 for arg in args:
-                    name = arg[arg.index('- ')+1 : arg.index('(')].strip()
-                    desc = arg[arg.index(')')+1:].strip()
-                    md.write(f'\n- {name} {desc}')
+                    if arg.count('-') > 0:
+                        name = arg[arg.index('- ')+1 : arg.index('(')].strip()
+                        desc = arg[arg.index(')')+1:].strip()
+                        md.write(f'\n- {name} {desc}')
+                    else:
+                        md.write(f'\n  - {arg}')
                 md.write(f'\n\n**Returns**: {returns}')
+                md.write(f'\n##### Supports: _{", ".join(supports)}_')
+                md.write('\n----')
         except:
-            pass
+            print(f'Failed to build docs for {dec_name} in {filepath}')
+            print(f'Line: {line}')
+            raise
     print('docs built.')
             
             


### PR DESCRIPTION
## What is this? 
Updates for the doc generation and docstrings to specify DB support on an individual macro level.

Other fixes to docs generation have also been included as well as some minor updates to the README.

## What changes in this PR? 
* **Doc generator no longer ignores errors!**
* Docstring supports a `SUPPORTS` subsection to indicate which DBs the macro works for
* Extra lines in between arguments become sub-bullets of the primary arg bullet
* Fixed all docstrings that were silently failing.
* README now indicates the DB prereqs (i.e. `generate_uuid` in postgres)

## How does this impact our users?
* Output docs are more up to date and now more reliably built

## PR Quality
- [ ] does `docker-compose exec testxdb test` run successfully? (snowflake and postgres pass)
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 



@Health-Union/hu-data make sure to include a version tag in the merge commit!