### PR TITLE
Adds basic parse/cast to json datatype

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -185,6 +185,17 @@ This macro takes a number and adjusts the index based on programming language. W
 
 ##### Supports: _Postgres, Snowflake, BigQuery_
 ----
+### [cast_json](../macros/cast_json.sql)
+**xdb.cast_json** (**val** _string_)
+
+converts `val` to the basic json type in the target database
+
+- val : the value to be cast/parsed
+
+**Returns**:         The value typed as json
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [cast_timestamp](../macros/cast_timestamp.sql)
 **xdb.cast_timestamp** (**val** _identifier/date/timestamp_, **cast_as** _string_)
 

--- a/macros/cast_json.sql
+++ b/macros/cast_json.sql
@@ -8,9 +8,9 @@
             - Snowflake
     #}
     {%- if target.type ==  'postgres' -%} 
-        val::json
+        {{val}}::json
     {%- elif target.type == 'snowflake' -%}
-        parse_json(val)
+        parse_json({{val}})
     {%- else -%}
         {{ xdb.not_supported_exception('cast_json') }}
     {%- endif -%}

--- a/macros/cast_json.sql
+++ b/macros/cast_json.sql
@@ -8,7 +8,7 @@
             - Snowflake
     #}
     {%- if target.type ==  'postgres' -%} 
-        {{val}}::json
+        {{val}}::jsonb
     {%- elif target.type == 'snowflake' -%}
         parse_json({{val}})
     {%- else -%}

--- a/macros/cast_json.sql
+++ b/macros/cast_json.sql
@@ -1,0 +1,17 @@
+{%- macro cast_json(val) -%}
+    {# converts `val` to the basic json type in the target database
+       ARGS:
+         - val (string) the value to be cast/parsed
+       RETURNS: The value typed as json
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+    #}
+    {%- if target.type ==  'postgres' -%} 
+        val::json
+    {%- elif target.type == 'snowflake' -%}
+        parse_json(val)
+    {%- else -%}
+        {{ xdb.not_supported_exception('cast_json') }}
+    {%- endif -%}
+{%- endmacro -%}

--- a/macros/cast_json.sql
+++ b/macros/cast_json.sql
@@ -1,7 +1,7 @@
 {%- macro cast_json(val) -%}
     {# converts `val` to the basic json type in the target database
        ARGS:
-         - val (string) the value to be cast/parsed
+         - val (string): the value to be cast/parsed
        RETURNS: The value typed as json
        SUPPORTS:
             - Postgres

--- a/macros/json_extract_path_text.sql
+++ b/macros/json_extract_path_text.sql
@@ -15,7 +15,7 @@
             - Snowflake
   #}
   {%- if target.type == 'postgres' -%}
-    {%- set expr = namespace(value="json_extract_path_text(" ~ column ~ ", ") -%}
+    {%- set expr = namespace(value="jsonb_extract_path_text(" ~ column ~ ", ") -%}
     {%- for val in path_vals -%}
       {%- set expr.value = expr.value ~ "'" ~ val ~ "'" -%}
       {%- if not loop.last -%}

--- a/test_xdb/models/schema_tests/cast_json.yml
+++ b/test_xdb/models/schema_tests/cast_json.yml
@@ -1,0 +1,16 @@
+version: 2
+
+models:
+    - name: cast_json_test
+      description: "tests cast_json macro"
+      columns:
+          - name: value1
+            tests:
+              - not_null
+              - accepted_values:
+                  values: ['value1']
+          - name: value3
+            tests:
+              - not_null
+              - accepted_values:
+                  values: ["-1234"]

--- a/test_xdb/models/under_test/cast_json_test.sql
+++ b/test_xdb/models/under_test/cast_json_test.sql
@@ -1,0 +1,20 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+
+with test_raw_data as (
+    select
+        '{"key1":"value1", "key2":{"innerkey2_1":"innervalue2_1", "0":[0, null, "string"]}, "key3": -1234}'
+            as varchar_json
+)
+, test_json_data as (
+    select {{xdb.cast_json("varchar_json")}} as json_col from test_raw_data
+)
+
+select
+    {% if target.type == 'postgres' %}
+        json_col->>'key1' as value1,
+        json_col->>'key3' as value3
+    {% elif target.type == 'snowflake' %}
+        json_col:key1 as value1,
+        json_col:key3 as value3
+    {% endif %}
+from test_json_data

--- a/test_xdb/models/under_test/json_extract_path_text_test.sql
+++ b/test_xdb/models/under_test/json_extract_path_text_test.sql
@@ -3,7 +3,7 @@
 with test_json_data as (
     select
         {% set js = '{"key1":"value1", "key2":{"innerkey2_1":"innervalue2_1", "0":[0, null, "string"]}, "key3": -1234}' %}
-        {% if target.type == 'postgres' %}'{{js}}'::json
+        {% if target.type == 'postgres' %}'{{js}}'::jsonb
         {% elif target.type == 'snowflake' %}parse_json('{{js}}')
         {% endif %}
             as json_col


### PR DESCRIPTION
## What is this? 
This adds a simple function to cast/parse a string into the appropriate json datatype since there isn't a uniform way to do that.

## What changes in this PR? 
* The `cast_json` macro is added for snowflake and postgres
* Types returned are the appropriate datatypes for `json_extract_path_text` macro
* Postgres returns the basic `json` datatype
* Snowflake returns a `variant` datatype

## How does this impact our users?
* Better cross database json support

## PR Quality
- [ ] does `docker-compose exec testxdb test` run successfully? (snowflake and postgres pass
- [X] does `docker-compose exec testxdb docs` build docs without errors?
- [X] does `docker-compose exec testxdb coverage` pass coverage standards?
- [X] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!