### PR TITLE
added split test for bigquery

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -173,6 +173,18 @@ applies the weird escape sequences required for bigquery and snowflake
 **Returns**: 
 ##### Supports: _Postgres, Snowflake, BigQuery, Redshift_
 ----
+### [array_contains](../macros/array_contains.sql)
+**xdb.array_contains** (**array_values** _array_, **contained_value** _string_)
+
+This macro is used to determine if an array contains a certain value
+
+- array_values the array to check for the value
+- contained_value the value to check the array for
+
+**Returns**:          The appropriate sql syntax needed to check if the array contains the value
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [array_index](../macros/array_index.sql)
 **xdb.array_index** (**index** _None_)
 

--- a/test_xdb/models/under_test/split_test.sql
+++ b/test_xdb/models/under_test/split_test.sql
@@ -1,5 +1,3 @@
-/* TODO split is supported for bigquery. tests should support that */
-
 {% if target.type == 'postgres' %}
     {% set arr_len_func = 'array_length' %}
     {% set arr_len_xarg = ',1' %}

--- a/test_xdb/models/under_test/split_test.sql
+++ b/test_xdb/models/under_test/split_test.sql
@@ -1,11 +1,13 @@
 /* TODO split is supported for bigquery. tests should support that */
-{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
 
 {% if target.type == 'postgres' %}
     {% set arr_len_func = 'array_length' %}
     {% set arr_len_xarg = ',1' %}
 {% elif target.type == 'snowflake' %}
     {% set arr_len_func = 'array_size' %}
+    {% set arr_len_xarg = '' %}
+{% elif target.type == 'bigquery' %}
+    {% set arr_len_func = 'array_length' %}
     {% set arr_len_xarg = '' %}
 {% endif %}
 


### PR DESCRIPTION
## What is this? 
Added a split test for bigquery

## What changes in this PR? 
Checked bigquery tests with `docker-compose exec testxdb test` and generated new docs with `docker-compose exec testxdb docs` (also ran coverage).

## How does this impact our users?
Allows split macro to be used in bigquery.

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully?
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!