### PR TITLE
Fix concat null edge case 

### DIFF
--- a/macros/concat.sql
+++ b/macros/concat.sql
@@ -42,13 +42,13 @@
     {%- for field in fields -%}
         {%- if target.type in ('postgres','snowflake',)  -%}
             {%- if convert_null -%}
-                {%- set field_casted = "CASE WHEN " ~ field ~ " IS NULL THEN 'NULL'::varchar ELSE " ~ field ~ "::varchar END" -%}
+                {%- set field_casted = "CASE WHEN " ~ field ~ "::varchar IS NULL THEN 'NULL'::varchar ELSE " ~ field ~ "::varchar END" -%}
             {%- else -%}
                 {%- set field_casted = field ~ "::varchar" -%}
             {%- endif -%}
         {%- elif target.type == 'bigquery' -%}
             {%- if convert_null -%}
-                {%- set field_casted = "CASE WHEN " ~ field ~ " IS NULL THEN CAST('NULL' AS STRING) ELSE CAST(" ~ field ~ " AS STRING) END" -%}
+                {%- set field_casted = "CASE WHEN CAST(" ~ field ~ " AS STRING) IS NULL THEN CAST('NULL' AS STRING) ELSE CAST(" ~ field ~ " AS STRING) END" -%}
             {%- else -%}
                 {%- set field_casted = "CAST(" ~ field ~ " AS STRING)"-%}
             {%- endif -%}

--- a/test_xdb/models/schema_tests/concat.yml
+++ b/test_xdb/models/schema_tests/concat.yml
@@ -63,3 +63,8 @@ models:
               - accepted_values:
                   values: ['NULL']
                   quote: false
+          # test field for the case when col is not null, but col::varchar is null
+          # only known case is 'null' json object in snowflake
+          - name: has_js_null_field
+            tests:
+              - not_null


### PR DESCRIPTION
## What is this? 
FIxes an edge case where casting as a varchar generated `NULL` columns to concatenate (when explicitly set to concat `NULL`s as the varchar `'NULL'`)

### Example:
Only known case is a json typed `'null'` value in Snowflake where casting changes a SQL `is NULL` check.
``` SQL
select 
    parse_json('{"key":"value","key2":null}'):key2 is null as in_object_null_check
    , parse_json('{"key":"value","key2":null}'):key2::varchar is null as in_object_null_varchar_check
    , parse_json('null') is null as object_null_check
    , parse_json('null')::varchar is null as object_null_varchar_check
```

## What changes in this PR? 
* added a test for the edge case (only happens in snowflake)
* the concat `NULL` check happens on the casted column value instead of the raw column value

## How does this impact our users?
* Should fix an edge case without changing the normal behavior of `concat`

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully? (postgres & snowflake)
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 
