### PR TITLE
updating the doc generation script to strip out sql comment indicators

### DIFF
--- a/test_xdb/scripts/macrodocs.py
+++ b/test_xdb/scripts/macrodocs.py
@@ -59,7 +59,7 @@ def macrodocs(macros_folder, docs_file, header_text, prefix=None):
                     in_return,in_args,in_description,in_support = False,False,False,True
 
                 if in_description:
-                    description += line.replace('{#','').replace('#}','')
+                    description += line.replace('{#','').replace('#}','').replace('/*','')
 
                 if in_args:
                     if 'ARGS:' not in line.upper():


### PR DESCRIPTION
## What is this? 
this updates the doc generation script to strip out sql comment indicator
## What changes in this PR? 
the docs generated no longer includes sql comment indicator

## How does this impact our users?
makes the docs more neat

## PR Quality
- [ ] does `docker-compose exec testxdb test` run successfully?
- [ ] does `docker-compose exec testxdb docs` build docs without errors?
- [ ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ ] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!