### PR TITLE
First release of get_email_domain_extension.

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -236,6 +236,17 @@ converts `val` to the basic json type in the target database
 
 ##### Supports: _Postgres, Snowflake_
 ----
+### [get_email_domain_extension](../macros/get_email_domain_extension.sql)
+**xdb.get_email_domain_extension** (**string** _string_)
+
+/* Returns the domain extension of an email address (e.g. 'com', 'net', 'co.uk').
+
+- string email address to be processed.
+
+**Returns**:         The requested part of an email address.
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [get_time_slice](../macros/get_time_slice.sql)
 **xdb.get_time_slice** (**date_or_time_expr** _date or time_, **slice_length** _int_, **date_or_time_part** _string_, **start_or_end** _string_)
 

--- a/macros/get_email_domain_extension.sql
+++ b/macros/get_email_domain_extension.sql
@@ -1,0 +1,19 @@
+{%- macro get_email_domain_extension(string) -%}
+    {#/* Returns the domain extension of an email address (e.g. 'com', 'net', 'co.uk').
+       ARGS:
+         - string (string) email address to be processed.
+       RETURNS: The requested part of an email address.
+       SUPPORTS:
+         - Postgres
+         - Snowflake
+    */#}
+{%- if target.type ==  'postgres' -%}
+SUBSTRING(SUBSTRING({{string}}, STRPOS({{string}}, '@') +1, LENGTH({{string}})), STRPOS(SUBSTRING({{string}}, STRPOS({{string}}, '@'), LENGTH({{string}})), '.'), LENGTH({{string}}))
+   
+{%- elif target.type == 'snowflake' -%}
+SUBSTRING(SUBSTRING({{string}}, CHARINDEX('@', {{string}}) +1, LENGTH({{string}})), CHARINDEX('.', SUBSTRING({{string}}, CHARINDEX('@', {{string}}), LENGTH({{string}}))), LENGTH({{string}}))
+
+{%- else -%}
+    {{ xdb.not_supported_exception('get_email_domain_extension') }}
+{%- endif -%}
+{%- endmacro -%}

--- a/test_xdb/models/schema_tests/get_email_domain_extension.yml
+++ b/test_xdb/models/schema_tests/get_email_domain_extension.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+    - name: get_email_domain_extension_test
+      description: "tests expected values"
+      columns:
+          - name: username_w_dot_com
+            tests:
+              - accepted_values:
+                  values: ['com']
+              - not_null
+          - name: username_wo_dot_net
+            tests:
+              - accepted_values:
+                  values: ['net']
+              - not_null
+          - name: username_w_dot_co_uk
+            tests:
+              - accepted_values:
+                  values: ['co.uk']
+              - not_null
+          - name: username_wo_dot_com_ar
+            tests:
+              - accepted_values:
+                  values: ['com.ar']
+              - not_null

--- a/test_xdb/models/under_test/get_email_domain_extension_test.sql
+++ b/test_xdb/models/under_test/get_email_domain_extension_test.sql
@@ -1,0 +1,18 @@
+{{ config(tags=["exclude_bigquery","exclude_bigquery_tests"]) }}
+
+WITH
+source_data AS (
+    SELECT
+        'john.doe@dummy.com' AS username_w_dot_com_data
+	, 'johndoe@dummy.net' AS username_wo_dot_net_data
+	, 'john.doe@dummy.co.uk' AS username_w_dot_co_uk_data
+	, 'johndoe@dummy.com.ar' AS username_wo_dot_com_ar_data
+)
+
+SELECT
+    {{ xdb.get_email_domain_extension('username_w_dot_com_data') }} AS username_w_dot_com
+    , {{ xdb.get_email_domain_extension('username_wo_dot_net_data') }} AS username_wo_dot_net
+    , {{ xdb.get_email_domain_extension('username_w_dot_co_uk_data') }} AS username_w_dot_co_uk
+    , {{ xdb.get_email_domain_extension('username_wo_dot_com_ar_data') }} AS username_wo_dot_com_ar
+FROM
+    source_data


### PR DESCRIPTION
## What is this? 
A function that returns the domain extension of an email address (e.g. 'com', 'net', 'co.uk')

## What changes in this PR? 
First release.

## How does this impact our users?
Developers can easily retrieve the domain extension of an email address is both Postgre and Snowflake.

## PR Quality
- [x] does `docker-compose exec testxdb test` run successfully?
- [x] does `docker-compose exec testxdb docs` build docs without errors?
- [x] does `docker-compose exec testxdb coverage` pass coverage standards?
- [x] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!