### PR TITLE
DATA-2618: the env_generate_schema_name macro was added

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -4,6 +4,20 @@
 These macros carry functionality across **Snowflake** and **Postgresql**, and most also support **BigQuery**. Individual support listed below.
 
 
+### [env_generate_schema_name](../macros/env_generate_schema_name.sql)
+**xdb.env_generate_schema_name** (**custom_schema_name** _string_, **branch_name** _string_, **default_schema** _string_)
+
+/* Used in conjunction with generate_schema_name, this macro returns a schema name
+        based on the cusrrent working environment
+
+- custom_schema_name The configured value of schema in the specified node, or none if a value is not supplied
+- branch_name The current branch name
+- default_schema The default schema name e.g. target.schema
+
+**Returns**:         A schema name.
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [hash](../macros/hash.sql)
 **xdb.hash** (**fields** _list_)
 
@@ -33,6 +47,15 @@ These macros carry functionality across **Snowflake** and **Postgresql**, and mo
 
 **Returns**: 
 ##### Supports: _All_
+----
+### [_dev_schema](../macros/env_generate_schema_name.sql)
+**xdb._dev_schema** (**branch_name** _None_)
+
+
+
+
+**Returns**: 
+##### Supports: __
 ----
 ### [_fold](../macros/fold.sql)
 **xdb._fold** (**val** _string_)

--- a/macros/env_generate_schema_name.sql
+++ b/macros/env_generate_schema_name.sql
@@ -19,13 +19,13 @@
     {%- endif -%}
   {%- else -%}
     {%- if custom_schema_name is none -%}
-      {{ xdb._dev_schema(branch_name) }}_{{ default_schema }}
+      {{ xdb._normalize_schema(branch_name) }}_{{ default_schema }}
     {%- else -%}
-      {{ xdb._dev_schema(branch_name) }}_{{ default_schema }}_{{ custom_schema_name | trim }}
+      {{ xdb._normalize_schema(branch_name) }}_{{ default_schema }}_{{ custom_schema_name | trim }}
     {%- endif -%}
   {%- endif -%}
 {%- endmacro %}
 
-{%- macro _dev_schema(branch_name) -%}
+{%- macro _normalize_schema(branch_name) -%}
   {{ branch_name | replace('/','') | replace('-','') | replace('_','') | lower}}
 {%- endmacro -%}

--- a/macros/env_generate_schema_name.sql
+++ b/macros/env_generate_schema_name.sql
@@ -1,0 +1,31 @@
+/* xdb: nocoverage */
+{% macro env_generate_schema_name(custom_schema_name, branch_name, default_schema) -%}
+{#/* Used in conjunction with generate_schema_name, this macro returns a schema name
+        based on the cusrrent working environment
+       ARGS:
+         - custom_schema_name (string) The configured value of schema in the specified node, or none if a value is not supplied
+         - branch_name (string) The current branch name
+         - default_schema (string) The default schema name e.g. target.schema
+       RETURNS: A schema name.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+    */#}  
+  {%- if branch_name == '' -%}
+    {%- if custom_schema_name is none -%}
+      {{ default_schema }}
+    {%- else -%}
+      {{ default_schema }}_{{ custom_schema_name | trim }}
+    {%- endif -%}
+  {%- else -%}
+    {%- if custom_schema_name is none -%}
+      {{ xdb._dev_schema(branch_name) }}_{{ default_schema }}
+    {%- else -%}
+      {{ xdb._dev_schema(branch_name) }}_{{ default_schema }}_{{ custom_schema_name | trim }}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro %}
+
+{%- macro _dev_schema(branch_name) -%}
+  {{ branch_name | replace('/','') | replace('-','') | replace('_','') | lower}}
+{%- endmacro -%}


### PR DESCRIPTION
## What is this? 
_The env_generate_schema_name general macro was added._

## What changes in this PR? 
* _The new generic macro was introduced - env_generate_schema_name, it generates the schema name based on the current environment_

## How does this impact our users?
* _it will be used in the datascience, datawarehouse and datalake repos_

## PR Quality
- [Y] does `docker-compose exec testxdb test` run successfully?
- [Y ] does `docker-compose exec testxdb docs` build docs without errors?
- [Y ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ Y] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!