### PR TITLE
feature/data 3045 Update of timeadd() macro

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -48,15 +48,6 @@ These macros carry functionality across **Snowflake** and **Postgresql**, and mo
 **Returns**: 
 ##### Supports: _All_
 ----
-### [_dev_schema](../macros/env_generate_schema_name.sql)
-**xdb._dev_schema** (**branch_name** _None_)
-
-
-
-
-**Returns**: 
-##### Supports: __
-----
 ### [_fold](../macros/fold.sql)
 **xdb._fold** (**val** _string_)
 
@@ -67,6 +58,15 @@ These macros carry functionality across **Snowflake** and **Postgresql**, and mo
 **Returns**:      `val` either upper or lowercase (or unfolded), per the target adapter spec.
 
 ##### Supports: _Postgres, Snowflake, BigQuery, _
+----
+### [_normalize_schema](../macros/env_generate_schema_name.sql)
+**xdb._normalize_schema** (**branch_name** _None_)
+
+
+
+
+**Returns**: 
+##### Supports: __
 ----
 ### [_not_supported_exception](../macros/not_supported_exception.sql)
 **xdb._not_supported_exception** (**_name** _None_)
@@ -512,14 +512,15 @@ tests that `substring` is not contained in `column_name`
 ##### Supports: _Most (requires basic CTE support)_
 ----
 ### [timeadd](../macros/timeadd.sql)
-**xdb.timeadd** (**part** _string_, **amount_to_add** _int_, **value** _string_)
+**xdb.timeadd** (**part** _string_, **amount_to_add** _int_, **value** _string_, **timestamp_cast_flag** _boolean_)
 
 /* adds `amount_to_add` `part`s to `value`. so adding one hour to Jan 1 2020 01:00:00 would be timeadd('hour',1,'2020-01-01 01:00:00').
-       NOTE: timeadd only manipulates time values. for date additions see [dateadd](#dateadd)
+       NOTE: timeadd can handle either string or date/time types passed in `value`.
 
 - part one of 'second','minute','hour'.
 - amount_to_add number of `part` units to add to `value`. Negative subtracts.
 - value the date time string or column to add to.
+- timestamp_cast_flag indicates if `value` should be internally casted to timestamp type
 
 **Returns**:         a date time value with the amount added.
 

--- a/macros/cast_timestamp.sql
+++ b/macros/cast_timestamp.sql
@@ -16,9 +16,9 @@
 
 {%- if target.type ==  'postgres' -%} 
     {%- if cast_as in ('timestamp_ntz','timestamp') -%}
-        {{val}}::TIMESTAMP WITH TIME ZONE
-    {%- elif cast_as == 'timestamp_tz' -%}
         {{val}}::TIMESTAMP WITH TIME ZONE AT TIME ZONE 'UTC'
+    {%- elif cast_as == 'timestamp_tz' -%}
+        {{val}}::TIMESTAMP WITH TIME ZONE
     {%- endif -%}
 
 {%- elif target.type == 'bigquery' -%}

--- a/macros/cast_timestamp.sql
+++ b/macros/cast_timestamp.sql
@@ -16,9 +16,9 @@
 
 {%- if target.type ==  'postgres' -%} 
     {%- if cast_as in ('timestamp_ntz','timestamp') -%}
-        {{val}}::TIMESTAMP
+        {{val}}::TIMESTAMP WITH TIME ZONE
     {%- elif cast_as == 'timestamp_tz' -%}
-        {{val}}::TIMESTAMP AT TIME ZONE 'UTC'
+        {{val}}::TIMESTAMP WITH TIME ZONE AT TIME ZONE 'UTC'
     {%- endif -%}
 
 {%- elif target.type == 'bigquery' -%}

--- a/macros/cast_timestamp.sql
+++ b/macros/cast_timestamp.sql
@@ -16,9 +16,9 @@
 
 {%- if target.type ==  'postgres' -%} 
     {%- if cast_as in ('timestamp_ntz','timestamp') -%}
-        {{val}}::TIMESTAMP WITH TIME ZONE AT TIME ZONE 'UTC'
+        {{val}}::TIMESTAMP
     {%- elif cast_as == 'timestamp_tz' -%}
-        {{val}}::TIMESTAMP WITH TIME ZONE
+        {{val}}::TIMESTAMP AT TIME ZONE 'UTC'
     {%- endif -%}
 
 {%- elif target.type == 'bigquery' -%}

--- a/macros/timeadd.sql
+++ b/macros/timeadd.sql
@@ -1,6 +1,6 @@
 {%- macro timeadd(part, amount_to_add, value, timestamp_cast_flag=true) -%}
     {#/* adds `amount_to_add` `part`s to `value`. so adding one hour to Jan 1 2020 01:00:00 would be timeadd('hour',1,'2020-01-01 01:00:00').
-       NOTE: timeadd only manipulates time values. for date additions see [dateadd](#dateadd)
+       NOTE: timeadd can handle either string or date/time types passed in `value`.
        ARGS:
          - part (string) one of 'second','minute','hour'.
          - amount_to_add (int) number of `part` units to add to `value`. Negative subtracts.

--- a/macros/timeadd.sql
+++ b/macros/timeadd.sql
@@ -5,6 +5,7 @@
          - part (string) one of 'second','minute','hour'.
          - amount_to_add (int) number of `part` units to add to `value`. Negative subtracts.
          - value (string) the date time string or column to add to.
+         - timestamp_cast_flag (boolean) indicates if `value` should be internally casted to timestamp type
        RETURNS: a date time value with the amount added.
        SUPPORTS:
             - Postgres

--- a/test_xdb/models/under_test/timeadd_test.sql
+++ b/test_xdb/models/under_test/timeadd_test.sql
@@ -1,3 +1,5 @@
+{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+
 WITH
 source_data AS (
     SELECT 
@@ -5,6 +7,7 @@ source_data AS (
         , '2020-01-01 00:00:00'::TIMESTAMP AS date_col_timestamp
 )
 
+, string_handled_data AS (
 SELECT
 --cast to timestamp logic block check
     {{xdb.timeadd('second', '1', 'date_col_string')}} AS one_second_added
@@ -13,13 +16,27 @@ SELECT
     , {{xdb.timeadd('minute', '-1', 'date_col_string')}} AS one_minute_subtracted
     , {{xdb.timeadd('hour', '1', 'date_col_string')}} AS one_hour_added
     , {{xdb.timeadd('hour', '-1', 'date_col_string')}} AS one_hour_subtracted
---NO cast to timestamp logic block check
-    , {{xdb.timeadd('second', '1', 'date_col_timestamp', false)}} AS no_cast_one_second_added
-    , {{xdb.timeadd('second', '-1', 'date_col_timestamp', false)}} AS no_cast_one_second_subtracted
-    , {{xdb.timeadd('minute', '1', 'date_col_timestamp', false)}} AS no_cast_one_minute_added
-    , {{xdb.timeadd('minute', '-1', 'date_col_timestamp', false)}} AS no_cast_one_minute_subtracted
-    , {{xdb.timeadd('hour', '1', 'date_col_timestamp', false)}} AS no_cast_one_hour_added
-    , {{xdb.timeadd('hour', '-1', 'date_col_timestamp', false)}} AS no_cast_one_hour_subtracted
 FROM
     source_data
+)
 
+, timestamp_handled_data AS (
+SELECT
+--NO cast to timestamp logic block check
+    , {{xdb.timeadd('second', '1', 'date_col_timestamp', false)}} AS one_second_added
+    , {{xdb.timeadd('second', '-1', 'date_col_timestamp', false)}} AS one_second_subtracted
+    , {{xdb.timeadd('minute', '1', 'date_col_timestamp', false)}} AS one_minute_added
+    , {{xdb.timeadd('minute', '-1', 'date_col_timestamp', false)}} AS one_minute_subtracted
+    , {{xdb.timeadd('hour', '1', 'date_col_timestamp', false)}} AS one_hour_added
+    , {{xdb.timeadd('hour', '-1', 'date_col_timestamp', false)}} AS one_hour_subtracted
+FROM
+    source_data
+)
+
+, unioned_data AS (
+    SELECT * FROM timestamp_handled_data
+    UNION
+    SELECT * FROM string_handled_data
+)
+
+SELECT * FROM unioned_data

--- a/test_xdb/models/under_test/timeadd_test.sql
+++ b/test_xdb/models/under_test/timeadd_test.sql
@@ -1,15 +1,25 @@
 WITH
 source_data AS (
-    SELECT '2020-01-01 00:00:00' AS date_col
+    SELECT 
+        '2020-01-01 00:00:00' AS date_col_string
+        , '2020-01-01 00:00:00'::TIMESTAMP AS date_col_timestamp
 )
 
 SELECT
-    {{xdb.timeadd('second', '1', 'date_col')}} AS one_second_added
-    , {{xdb.timeadd('second', '-1', 'date_col')}} AS one_second_subtracted
-    , {{xdb.timeadd('minute', '1', 'date_col')}} AS one_minute_added
-    , {{xdb.timeadd('minute', '-1', 'date_col')}} AS one_minute_subtracted
-    , {{xdb.timeadd('hour', '1', 'date_col')}} AS one_hour_added
-    , {{xdb.timeadd('hour', '-1', 'date_col')}} AS one_hour_subtracted
+--cast to timestamp logic block check
+    {{xdb.timeadd('second', '1', 'date_col_string')}} AS one_second_added
+    , {{xdb.timeadd('second', '-1', 'date_col_string')}} AS one_second_subtracted
+    , {{xdb.timeadd('minute', '1', 'date_col_string')}} AS one_minute_added
+    , {{xdb.timeadd('minute', '-1', 'date_col_string')}} AS one_minute_subtracted
+    , {{xdb.timeadd('hour', '1', 'date_col_string')}} AS one_hour_added
+    , {{xdb.timeadd('hour', '-1', 'date_col_string')}} AS one_hour_subtracted
+--NO cast to timestamp logic block check
+    , {{xdb.timeadd('second', '1', 'date_col_timestamp', false)}} AS no_cast_one_second_added
+    , {{xdb.timeadd('second', '-1', 'date_col_timestamp', false)}} AS no_cast_one_second_subtracted
+    , {{xdb.timeadd('minute', '1', 'date_col_timestamp', false)}} AS no_cast_one_minute_added
+    , {{xdb.timeadd('minute', '-1', 'date_col_timestamp', false)}} AS no_cast_one_minute_subtracted
+    , {{xdb.timeadd('hour', '1', 'date_col_timestamp', false)}} AS no_cast_one_hour_added
+    , {{xdb.timeadd('hour', '-1', 'date_col_timestamp', false)}} AS no_cast_one_hour_subtracted
 FROM
     source_data
 

--- a/test_xdb/models/under_test/timeadd_test.sql
+++ b/test_xdb/models/under_test/timeadd_test.sql
@@ -23,7 +23,7 @@ FROM
 , timestamp_handled_data AS (
 SELECT
 --NO cast to timestamp logic block check
-    , {{xdb.timeadd('second', '1', 'date_col_timestamp', false)}} AS one_second_added
+    {{xdb.timeadd('second', '1', 'date_col_timestamp', false)}} AS one_second_added
     , {{xdb.timeadd('second', '-1', 'date_col_timestamp', false)}} AS one_second_subtracted
     , {{xdb.timeadd('minute', '1', 'date_col_timestamp', false)}} AS one_minute_added
     , {{xdb.timeadd('minute', '-1', 'date_col_timestamp', false)}} AS one_minute_subtracted


### PR DESCRIPTION
## What is this? 
* refinement of logic of timeadd() and cast_timestamp() macros

## What changes in this PR? 
* addition of new argument timestamp_cast_flag to timeadd() macro
* update of corresponding tests

## How does this impact our users?
* update of timeadd() macro helps to fix the issue with timezones in https://bitbucket.org/healthunion/hu-dw-datawarehouse/pull-requests/365 against Snowflake and Postgres targets

## PR Quality
- [ ] does `docker-compose exec testxdb test` run successfully? - Have an error related to connection to test Snowflake DB.
- [*] does `docker-compose exec testxdb docs` build docs without errors?
- [*] does `docker-compose exec testxdb coverage` pass coverage standards?
- [*] did you leave the codebase better than you found it? 

@Health-Union/hu-data make sure to include a version tag in the merge commit!