### PR TITLE
Adding of new macro swap_schema(), minor common updates and fixes.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_PASSWORD: testxdb
       POSTGRES_USER: testxdb
       POSTGRES_DB: testxdb
+    ports:
+      - "5432:5432"
 
   testxdb:
     image: testxdb

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -30,6 +30,18 @@ These macros carry functionality across **Snowflake** and **Postgresql**, and mo
 
 ##### Supports: _Postgres, Snowflake, BigQuery_
 ----
+### [swap_schema](../macros/swap_schema.sql)
+**xdb.swap_schema** (**schema_one** _string_, **schema_two** _string_)
+
+/* Swaps the names between two specified schemas.
+
+- schema_one : name of first schema.
+- schema_two : name of second schema.
+
+**Returns**:         nothing to the call point.
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [_concat_cast_fields](../macros/concat.sql)
 **xdb._concat_cast_fields** (**fields** _None_, **convert_null** _None_)
 

--- a/macros/swap_schema.sql
+++ b/macros/swap_schema.sql
@@ -1,0 +1,33 @@
+{% macro swap_schema(schema_one, schema_two) %}
+
+    {#/* Swaps the names between two specified schemas.
+       ARGS:
+         - schema_one (string) : name of first schema.
+         - schema_two (string) : name of second schema.
+       RETURNS: nothing to the call point.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+    */#}
+
+    {%- if target.type == 'postgres' -%} 
+        {% set sql %}
+            ALTER SCHEMA {{schema_one}} RENAME TO tmp_schema;
+            ALTER SCHEMA {{schema_two}} RENAME TO {{schema_one}};
+            ALTER SCHEMA tmp_schema RENAME TO {{schema_two}};
+        {% endset %}
+
+    {%- elif target.type == 'snowflake' -%}
+        {% set sql %}
+            ALTER SCHEMA {{schema_one}} SWAP WITH {{schema_two}};
+        {% endset %}
+
+    {%- else -%}
+        {{ xdb.not_supported_exception('The swap_schema() macro doesn`t support this type of database target.') }}
+    {%- endif -%}
+
+    {% do run_query(sql) %}
+
+    {{ log("Schema's names were swapped successfully.", info=True) }}
+
+{% endmacro %}

--- a/test_xdb/models/schema_tests/swap_schema_test.yml
+++ b/test_xdb/models/schema_tests/swap_schema_test.yml
@@ -1,0 +1,21 @@
+version: 2
+
+models:
+    - name: swap_schema_test
+      description: "tests that swap_schema() macro swaps the names between two specified schemas"
+      columns:
+          - name: object_type
+            tests:
+              - accepted_values:
+                  values: ['base table','sequence','view']
+              - not_null
+          - name: schema_one
+            tests:
+              - accepted_values:
+                  values: ['table_2','sequence_2','view_2']
+              - not_null
+          - name: schema_two
+            tests:
+              - accepted_values:
+                  values: ['table_1','sequence_1','view_1']
+              - not_null

--- a/test_xdb/models/under_test/generate_uuid_test.sql
+++ b/test_xdb/models/under_test/generate_uuid_test.sql
@@ -1,4 +1,12 @@
-{{ config({"tags":["exclude_bigquery", "exclude_bigquery_tests"]}) }}
+{{ config({
+    "tags":["exclude_bigquery", "exclude_bigquery_tests"],
+    "pre-hook": [{"sql": '{%- if target.type == "postgres" -%}
+                          CREATE EXTENSION "uuid-ossp";
+                          {%- endif -%}'}],
+    "post-hook": [{"sql": '{%- if target.type == "postgres" -%}
+                          DROP EXTENSION "uuid-ossp";
+                          {%- endif -%}'}]})
+}}
 
 WITH uuids AS (
     SELECT {{xdb.generate_uuid()}} AS uuid_varchar

--- a/test_xdb/models/under_test/generate_uuid_test.sql
+++ b/test_xdb/models/under_test/generate_uuid_test.sql
@@ -1,7 +1,7 @@
 {{ config({
     "tags":["exclude_bigquery", "exclude_bigquery_tests"],
     "pre-hook": [{"sql": '{%- if target.type == "postgres" -%}
-                          CREATE EXTENSION "uuid-ossp";
+                          CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
                           {%- endif -%}'}],
     "post-hook": [{"sql": '{%- if target.type == "postgres" -%}
                           DROP EXTENSION "uuid-ossp";

--- a/test_xdb/models/under_test/swap_schema_test.sql
+++ b/test_xdb/models/under_test/swap_schema_test.sql
@@ -21,7 +21,7 @@ WITH test_objects_metadata AS (
         , table_name AS object_name
     FROM information_schema.tables
     WHERE table_schema IN ('schema_one','schema_two')
-    UNION
+    UNION ALL
     SELECT
         'sequence' AS object_type
         , sequence_schema AS schema_name

--- a/test_xdb/models/under_test/swap_schema_test.sql
+++ b/test_xdb/models/under_test/swap_schema_test.sql
@@ -1,0 +1,38 @@
+{{config({
+    "tags":["exclude_bigquery", "exclude_bigquery_tests"],
+    "pre-hook": [{"sql": "CREATE SCHEMA schema_one;
+                          CREATE TABLE schema_one.table_1 AS select 1 AS column_1;
+                          CREATE VIEW schema_one.view_1 AS select 1 AS column_1;
+                          CREATE SEQUENCE schema_one.sequence_1;
+                          CREATE SCHEMA schema_two;
+                          CREATE TABLE schema_two.table_2 AS select 2 AS column_2;
+                          CREATE VIEW schema_two.view_2 AS select 2 AS column_2;
+                          CREATE SEQUENCE schema_two.sequence_2;"
+                          }, 
+                "{{ xdb.swap_schema('schema_one', 'schema_two') }}"],
+    "post-hook": [{"sql": "DROP SCHEMA schema_one CASCADE;
+                           DROP SCHEMA schema_two CASCADE;"}]})
+}}
+
+WITH test_objects_metadata AS (
+    SELECT
+        LOWER(table_type) AS object_type
+        , table_schema AS schema_name
+        , table_name AS object_name
+    FROM information_schema.tables
+    WHERE table_schema IN ('schema_one','schema_two')
+    UNION
+    SELECT
+        'sequence' AS object_type
+        , sequence_schema AS schema_name
+        , sequence_name AS object_name
+    FROM information_schema.sequences
+    WHERE sequence_schema IN ('schema_one','schema_two')
+)
+
+SELECT
+    object_type
+    , MAX(CASE WHEN (schema_name='schema_one') THEN object_name ELSE NULL END) AS schema_one
+    , MAX(CASE WHEN (schema_name='schema_two') THEN object_name ELSE NULL END) AS schema_two
+FROM test_objects_metadata
+GROUP BY 1

--- a/test_xdb/scripts/gather_targets.py
+++ b/test_xdb/scripts/gather_targets.py
@@ -1,12 +1,7 @@
 import yaml
-from test_setup import prepare_postgres_db
 
 def gather_targets(specified_targets=list()):
     with open('./profiles.yml','r') as f:
         profile = yaml.safe_load(f.read())
-
-    # handle any target specific setup that is needed (e.g. postgres extensions)
-    if 'postgres' in specified_targets or len(specified_targets) == 0:
-        prepare_postgres_db(profile['default']['outputs']['postgres'])
 
     return specified_targets if specified_targets else profile['default']['outputs']

--- a/test_xdb/scripts/test_setup.py
+++ b/test_xdb/scripts/test_setup.py
@@ -7,21 +7,3 @@ with open('./profiles.yml','r') as f:
     
 for target in profile['default']['outputs']:
     subprocess.call(['dbt','seed', '--profiles-dir','.','--target', target])
-
-
-def prepare_postgres_db(profile: dict):
-    """ Prepares the target postgres db for testing
-
-        Args:
-            - profile (dict): The loaded postgres yaml block from profiles.yml
-    """
-    user = profile['user']
-    password = profile['pass']
-    host = profile['host']
-    port = profile['port']
-    db = profile['dbname']
-    engine = create_engine(f"postgresql://{user}:{password}@{host}:{port}/{db}")
-    with engine.connect() as conn:
-        # install uuid-ossp for generating uuid fields
-        conn.execute('create extension if not exists "uuid-ossp"')
-    engine.dispose()


### PR DESCRIPTION
## What is this? 
This PR is about adding of new macro swap_schema(), which is able to swap the names between two specified schemas. It can be easily used (by `dbt run-operation` commands) as a part of potential Blue/Green Deploy of dbt projects.

## What changes in this PR? 
* _this adds new macro swap_schema() and corresponding tests to it._
* _this updates `profiles.yml` to make local testing process more comfortable._
* _this adds supportive hooks to `generate_uuid_test` model that fix testing of corresponding macro on Postgres target._

## How does this impact our users?
* _this provides new options for organisation of Blue/Green Deploy of dbt projects._

## PR Quality
- [+] does `docker-compose exec testxdb test` run successfully?
- [+] does `docker-compose exec testxdb docs` build docs without errors?
- [+] does `docker-compose exec testxdb coverage` pass coverage standards?
- [+] did you leave the codebase better than you found it? (I hope))




@Health-Union/hu-data make sure to include a version tag in the merge commit!