### PR TITLE
Adding of override_ref() macro

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -33,7 +33,7 @@ These macros carry functionality across **Snowflake** and **Postgresql**, and mo
 ### [override_ref](../macros/override_ref.sql)
 **xdb.override_ref** (**model_name** _string_)
 
-/* The macro which behaves as builtin macro `ref(), but omits database and schema rendering in references of views (this behaviour for Snowflake target only).
+/* The macro which behaves as builtin macro `ref()`, but omits database and schema rendering in references of views (this behaviour for Snowflake target only).
 
 - model_name : name of model.
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -30,6 +30,17 @@ These macros carry functionality across **Snowflake** and **Postgresql**, and mo
 
 ##### Supports: _Postgres, Snowflake, BigQuery_
 ----
+### [override_ref](../macros/override_ref.sql)
+**xdb.override_ref** (**model_name** _string_)
+
+/* The override version of builtin macro ref() that omits database and schema rendering in references of views (this behaviour for Snowflake target only).
+
+- model_name : name of model.
+
+**Returns**:         reference on corresponding object in target database.
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [swap_schema](../macros/swap_schema.sql)
 **xdb.swap_schema** (**schema_one** _string_, **schema_two** _string_)
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -33,7 +33,7 @@ These macros carry functionality across **Snowflake** and **Postgresql**, and mo
 ### [override_ref](../macros/override_ref.sql)
 **xdb.override_ref** (**model_name** _string_)
 
-/* The override version of builtin macro ref() that omits database and schema rendering in references of views (this behaviour for Snowflake target only).
+/* The macro which behaves as builtin macro `ref(), but omits database and schema rendering in references of views (this behaviour for Snowflake target only).
 
 - model_name : name of model.
 

--- a/macros/override_ref.sql
+++ b/macros/override_ref.sql
@@ -7,13 +7,9 @@
             - Postgres
             - Snowflake
     */#}
-
   {%- if model.config.materialized == 'view' and target.type == 'snowflake' -%}
     {% do return(builtins.ref(model_name).include(database=false, schema=false)) %}
-
   {%- else -%}
     {% do return(builtins.ref(model_name)) %}
-
   {%- endif -%}
-
 {% endmacro %}

--- a/macros/override_ref.sql
+++ b/macros/override_ref.sql
@@ -1,0 +1,19 @@
+{% macro override_ref(model_name) %}
+   {#/* The override version of builtin macro ref() that omits database and schema rendering in references of views (this behaviour for Snowflake target only).
+       ARGS:
+         - model_name (string) : name of model.
+       RETURNS: reference on corresponding object in target database.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+    */#}
+
+  {%- if model.config.materialized == 'view' and target.type == 'snowflake' -%}
+    {% do return(builtins.ref(model_name).include(database=false, schema=false)) %}
+
+  {%- else -%}
+    {% do return(builtins.ref(model_name)) %}
+
+  {%- endif -%}
+
+{% endmacro %}

--- a/macros/override_ref.sql
+++ b/macros/override_ref.sql
@@ -1,5 +1,5 @@
 {% macro override_ref(model_name) %}
-   {#/* The macro which behaves as builtin macro `ref(), but omits database and schema rendering in references of views (this behaviour for Snowflake target only).
+   {#/* The macro which behaves as builtin macro `ref()`, but omits database and schema rendering in references of views (this behaviour for Snowflake target only).
        ARGS:
          - model_name (string) : name of model.
        RETURNS: reference on corresponding object in target database.

--- a/macros/override_ref.sql
+++ b/macros/override_ref.sql
@@ -1,5 +1,5 @@
 {% macro override_ref(model_name) %}
-   {#/* The override version of builtin macro ref() that omits database and schema rendering in references of views (this behaviour for Snowflake target only).
+   {#/* The macro which behaves as builtin macro `ref(), but omits database and schema rendering in references of views (this behaviour for Snowflake target only).
        ARGS:
          - model_name (string) : name of model.
        RETURNS: reference on corresponding object in target database.

--- a/test_xdb/models/schema_tests/override_ref_test.yml
+++ b/test_xdb/models/schema_tests/override_ref_test.yml
@@ -1,0 +1,10 @@
+version: 2
+
+models:
+    - name: override_ref_test
+      description: "tests that override_ref() macro works properly with tables and views."
+      columns:
+          - name: reached_objects_count
+            tests:
+              - accepted_values:
+                  values: [3]

--- a/test_xdb/models/schema_tests/override_ref_with_swap_schema_test.yml
+++ b/test_xdb/models/schema_tests/override_ref_with_swap_schema_test.yml
@@ -1,0 +1,10 @@
+version: 2
+
+models:
+    - name: override_ref_with_swap_schema_test
+      description: "tests that override_ref() macro allows to query views properly after applying of swap_schema() macro."
+      columns:
+          - name: reached_views_count
+            tests:
+              - accepted_values:
+                  values: [2]

--- a/test_xdb/models/under_test/override_ref_test.sql
+++ b/test_xdb/models/under_test/override_ref_test.sql
@@ -1,4 +1,4 @@
-WITH test_objects_metadata AS (
+WITH unioned_data AS (
     SELECT status FROM {{ xdb.override_ref('override_ref_test_model_table') }}
     UNION ALL
     SELECT status FROM {{ xdb.override_ref('override_ref_test_model_view_based_on_table') }}
@@ -8,4 +8,4 @@ WITH test_objects_metadata AS (
 
 SELECT
     SUM(status) AS reached_objects_count
-FROM test_objects_metadata
+FROM unioned_data

--- a/test_xdb/models/under_test/override_ref_test.sql
+++ b/test_xdb/models/under_test/override_ref_test.sql
@@ -1,0 +1,11 @@
+WITH test_objects_metadata AS (
+    SELECT status FROM {{ xdb.override_ref('override_ref_test_model_table') }}
+    UNION ALL
+    SELECT status FROM {{ xdb.override_ref('override_ref_test_model_view_based_on_table') }}
+    UNION ALL
+    SELECT status FROM {{ xdb.override_ref('override_ref_test_model_view_based_on_view') }}
+)
+
+SELECT
+    SUM(status) AS reached_objects_count
+FROM test_objects_metadata

--- a/test_xdb/models/under_test/override_ref_test_model_table.sql
+++ b/test_xdb/models/under_test/override_ref_test_model_table.sql
@@ -1,5 +1,5 @@
 {{config({
-    "pre-hook": [{"sql": "CREATE SCHEMA ref_schema_one;"}],
+    "pre-hook": [{"sql": "CREATE SCHEMA IF NOT EXISTS ref_schema_one;"}],
     "materialized": "table",
     "schema": "ref_schema_one"})
 }}

--- a/test_xdb/models/under_test/override_ref_test_model_table.sql
+++ b/test_xdb/models/under_test/override_ref_test_model_table.sql
@@ -1,0 +1,7 @@
+{{config({
+    "pre-hook": [{"sql": "CREATE SCHEMA ref_schema_one;"}],
+    "materialized": "table",
+    "schema": "ref_schema_one"})
+}}
+
+SELECT 1 AS status

--- a/test_xdb/models/under_test/override_ref_test_model_view_based_on_table.sql
+++ b/test_xdb/models/under_test/override_ref_test_model_view_based_on_table.sql
@@ -1,0 +1,7 @@
+{{config({
+    "pre-hook": [{"sql": "CREATE SCHEMA IF NOT EXISTS ref_schema_one;"}],
+    "materialized": "view",
+    "schema": "ref_schema_one"})
+}}
+
+SELECT * FROM {{ xdb.override_ref('override_ref_test_model_table') }}

--- a/test_xdb/models/under_test/override_ref_test_model_view_based_on_view.sql
+++ b/test_xdb/models/under_test/override_ref_test_model_view_based_on_view.sql
@@ -1,0 +1,7 @@
+{{config({
+    "pre-hook": [{"sql": "CREATE SCHEMA IF NOT EXISTS ref_schema_one;"}],
+    "materialized": "view",
+    "schema": "ref_schema_one"})
+}}
+
+SELECT * FROM {{ xdb.override_ref('override_ref_test_model_view_based_on_table') }}

--- a/test_xdb/models/under_test/override_ref_with_swap_schema_test.sql
+++ b/test_xdb/models/under_test/override_ref_with_swap_schema_test.sql
@@ -9,7 +9,7 @@
                            DROP SCHEMA test_xdb_ref_schema_two CASCADE;"}]})
 }}
 
-WITH test_objects_metadata AS (
+WITH unioned_data AS (
     SELECT status FROM test_xdb_ref_schema_two.override_ref_test_model_view_based_on_table
     UNION ALL
     SELECT status FROM test_xdb_ref_schema_two.override_ref_test_model_view_based_on_view
@@ -17,4 +17,4 @@ WITH test_objects_metadata AS (
 
 SELECT
     SUM(status) AS reached_views_count
-FROM test_objects_metadata
+FROM unioned_data

--- a/test_xdb/models/under_test/override_ref_with_swap_schema_test.sql
+++ b/test_xdb/models/under_test/override_ref_with_swap_schema_test.sql
@@ -1,0 +1,20 @@
+
+-- depends_on: {{ ref('override_ref_test') }}
+
+{{config({
+    "tags":["exclude_bigquery", "exclude_bigquery_tests"],
+    "pre-hook": [{"sql": "CREATE SCHEMA test_xdb_ref_schema_two;"}, 
+                "{{ xdb.swap_schema('test_xdb_ref_schema_one', 'test_xdb_ref_schema_two') }}"],
+    "post-hook": [{"sql": "DROP SCHEMA test_xdb_ref_schema_one CASCADE;
+                           DROP SCHEMA test_xdb_ref_schema_two CASCADE;"}]})
+}}
+
+WITH test_objects_metadata AS (
+    SELECT status FROM test_xdb_ref_schema_two.override_ref_test_model_view_based_on_table
+    UNION ALL
+    SELECT status FROM test_xdb_ref_schema_two.override_ref_test_model_view_based_on_view
+)
+
+SELECT
+    SUM(status) AS reached_views_count
+FROM test_objects_metadata

--- a/test_xdb/profiles.yml
+++ b/test_xdb/profiles.yml
@@ -21,7 +21,7 @@ default:
       user: testxdb
       pass: testxdb
       dbname: testxdb
-      schema: prod
+      schema: test_xdb
 
 #    redshift:
 #      type: redshift


### PR DESCRIPTION
## What is this? 
_This PR adds `override_ref()`, which behaves as builtin macro `ref()`, but omits database and schema rendering in references of views (this behaviour for Snowflake target only). It is supposed to be used as override version of `ref()` in pair with `swap_schema()` macro as a part of potential Blue/Green Deploy of dbt projects._

## What changes in this PR? 
* _this adds new macro `override_ref()` and corresponding models and tests to it._
* _this changes Postgres testing schema's name in `profiles.yml` to make testing process more comfortable and unified._
* _this adds supportive model `override_ref_with_swap_schema_test.sql` and corresponding test which help to test work of `override_ref()` and `swap_schema()` macros in pair._

## How does this impact our users?
* _this provides new options for organisation of Blue/Green Deploy of dbt projects._
* _in case if `override_ref()` overrides builtin `ref()`, it makes using --defer flag during testing a bit more complex, namely if views are engaged, you should specify them before run of the model of your interest by separate commands with --defer flag too._

## PR Quality
- [ + ] does `docker-compose exec testxdb test` run successfully?
- [ + ] does `docker-compose exec testxdb docs` build docs without errors?
- [ + ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ + ] did you leave the codebase better than you found it? (It's my hope :-))

@Health-Union/hu-data make sure to include a version tag in the merge commit!