### PR TITLE
Adding of drop_schema() macro

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -4,6 +4,17 @@
 These macros carry functionality across **Snowflake** and **Postgresql**, and most also support **BigQuery**. Individual support listed below.
 
 
+### [drop_schema](../macros/drop_schema.sql)
+**xdb.drop_schema** (**schema_name** _string_)
+
+/* Drops schema named as `schema_name` and all its objects.
+
+- schema_name : name of schema that will be dropped.
+
+**Returns**:         nothing to the call point.
+
+##### Supports: _Postgres, Snowflake_
+----
 ### [env_generate_schema_name](../macros/env_generate_schema_name.sql)
 **xdb.env_generate_schema_name** (**custom_schema_name** _string_, **branch_name** _string_, **default_schema** _string_)
 

--- a/macros/drop_schema.sql
+++ b/macros/drop_schema.sql
@@ -1,0 +1,20 @@
+{% macro drop_schema(schema_name) %}
+
+    {#/* Drops schema named as `schema_name` and all its objects.
+       ARGS:
+         - schema_name (string) : name of schema that will be dropped.
+       RETURNS: nothing to the call point.
+       SUPPORTS:
+            - Postgres
+            - Snowflake
+    */#}
+
+  {% set sql %}
+      DROP SCHEMA IF EXISTS {{schema_name}} CASCADE;
+  {% endset %}
+
+  {% do run_query(sql) %}
+
+  {{ log("Schema " ~ schema_name ~ " was dropped successfully.", info=True) }}
+
+{% endmacro %}

--- a/test_xdb/models/schema_tests/drop_schema_test.yml
+++ b/test_xdb/models/schema_tests/drop_schema_test.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+    - name: drop_schema_test
+      description: "tests that drop_schema() macro drops passed schema and all its objects"
+      columns:
+          - name: schema_name
+            tests:
+              - accepted_values:
+                  values: ['drop_schema_test_schema']
+              - not_null
+          - name: schema_presence_flag
+            tests:
+              - accepted_values:
+                  values: ['false']
+              - not_null
+          - name: schema_tables_presence_flag
+            tests:
+              - accepted_values:
+                  values: ['false']
+              - not_null
+          - name: schema_sequences_presence_flag
+            tests:
+              - accepted_values:
+                  values: ['false']
+              - not_null

--- a/test_xdb/models/under_test/drop_schema_test.sql
+++ b/test_xdb/models/under_test/drop_schema_test.sql
@@ -1,0 +1,60 @@
+{{config({
+    "tags":["exclude_bigquery", "exclude_bigquery_tests"],
+    "pre-hook": [{"sql": "CREATE SCHEMA drop_schema_test_schema;
+                          CREATE TABLE drop_schema_test_schema.table_1 AS select 1 AS column_1;
+                          CREATE VIEW drop_schema_test_schema.view_1 AS select 1 AS column_1;
+                          CREATE SEQUENCE drop_schema_test_schema.sequence_1;"
+                          }, 
+                "{{ xdb.drop_schema('drop_schema_test_schema') }}"]})
+}}
+
+WITH lead_table AS (
+    SELECT 'drop_schema_test_schema' AS schema_name
+)
+
+, schema_presence AS (
+    SELECT
+        LOWER(schema_name) AS schema_name
+        , 1 AS schema_presence_flag
+    FROM information_schema.schemata
+    WHERE schema_name = 'drop_schema_test_schema'
+)
+
+, tables_count AS (
+    SELECT
+        LOWER(table_schema) AS schema_name
+        , COUNT(*) AS schema_tables_count
+    FROM information_schema.tables
+    WHERE table_schema = 'drop_schema_test_schema'
+    GROUP BY 1
+)
+
+, sequences_count AS (
+    SELECT
+        LOWER(sequence_schema) AS schema_name
+        , COUNT(*) AS schema_sequences_count
+    FROM information_schema.sequences
+    WHERE sequence_schema = 'drop_schema_test_schema'
+    GROUP BY 1
+)
+
+, joined_data AS (
+    SELECT
+        a.schema_name
+        , CASE WHEN b.schema_presence_flag = 1 THEN true ELSE false END AS schema_presence_flag
+        , CASE WHEN c.schema_tables_count IS NOT NULL THEN true ELSE false END AS schema_tables_presence_flag
+        , CASE WHEN d.schema_sequences_count IS NOT NULL THEN true ELSE false END AS schema_sequences_presence_flag
+    FROM lead_table AS a
+    LEFT JOIN
+    schema_presence AS b
+        ON a.schema_name = b.schema_name
+    LEFT JOIN
+    tables_count AS c
+        ON a.schema_name = c.schema_name
+    LEFT JOIN
+    sequences_count AS d
+        ON a.schema_name = d.schema_name
+)
+
+SELECT *
+FROM joined_data


### PR DESCRIPTION
## What is this? 
_This PR adds `drop_schema()`, which drops schema named as `schema_name` and all its objects. The macro is supposed as a part of potential Blue/Green Deploy of dbt projects._

## What changes in this PR? 
* _this adds new macro `drop_schema()` and corresponding models and tests for it._

## How does this impact our users?
* _this provides new options of data management might be useful for organisation of Blue/Green Deploy of dbt projects._

## PR Quality
- [ + ] does `docker-compose exec testxdb test` run successfully?
- [ + ] does `docker-compose exec testxdb docs` build docs without errors?
- [ + ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ + ] did you leave the codebase better than you found it? (Hope so.)

@Health-Union/hu-data make sure to include a version tag in the merge commit!