### PR TITLE
Data 4788 xdb add appropriate variants of now macros

### DIFF
--- a/macros/current_timestamp.sql
+++ b/macros/current_timestamp.sql
@@ -14,6 +14,8 @@
         CURRENT_TIMESTAMP at time zone ('{{ timezone }}')
     {%- elif target.type == 'snowflake' -%}
         CONVERT_TIMEZONE('{{ timezone }}', CURRENT_TIMESTAMP)
+    {%- else -%}
+        {{ not_supported_exception('current_timestamp') }}
     {%- endif -%}
 {%- endif -%}
 {%- endmacro -%}

--- a/macros/current_timestamp.sql
+++ b/macros/current_timestamp.sql
@@ -1,0 +1,19 @@
+{%- macro current_timestamp(timezone = None) -%}
+    {#/* Current timestamp function with time zone.
+      ARGS:
+        - Optional timezone(varchar): timezone that should be applied for timestamp
+      RETURNS: Current system timestamp with default timezone or provided one
+      SUPPORTS:
+        - Postgres
+        - Snowflake
+    */#}
+{%- if timezone is none -%}
+    CURRENT_TIMESTAMP
+{%- else -%}
+    {%- if target.type == 'postgres' -%}
+        CURRENT_TIMESTAMP at time zone ('{{ timezone }}')
+    {%- elif target.type == 'snowflake' -%}
+        CONVERT_TIMEZONE('{{ timezone }}', CURRENT_TIMESTAMP)
+    {%- endif -%}
+{%- endif -%}
+{%- endmacro -%}

--- a/macros/current_timestamp_ntz.sql
+++ b/macros/current_timestamp_ntz.sql
@@ -9,5 +9,7 @@
     NOW() at time zone ('UTC')
 {%- elif target.type == 'snowflake' -%}
     SYSDATE()
+{%- else -%}
+    {{ not_supported_exception('current_timestamp_ntz') }}
 {%- endif -%}
 {%- endmacro -%}

--- a/macros/current_timestamp_ntz.sql
+++ b/macros/current_timestamp_ntz.sql
@@ -1,0 +1,13 @@
+{%- macro current_timestamp_ntz() -%}
+    {#/* Current timestamp function without timezone info, UTC.
+      RETURNS: Current system timestamp without timezone, UTC.
+      SUPPORTS:
+        - Postgres
+        - Snowflake
+    */#}
+{%- if target.type == 'postgres' -%}
+    NOW() at time zone ('UTC')
+{%- elif target.type == 'snowflake' -%}
+    SYSDATE()
+{%- endif -%}
+{%- endmacro -%}

--- a/macros/like_any.sql
+++ b/macros/like_any.sql
@@ -14,6 +14,6 @@
 {%- elif target.type == 'snowflake' -%}
     LIKE ANY{{ patterns }} ESCAPE '{{ escape }}'
 {%- else -%}
-    {{ not_supported_exception('macro_name') }}
+    {{ not_supported_exception('like_any') }}
 {%- endif  -%}
 {%- endmacro -%}

--- a/test_xdb/models/schema_tests/current_timestamp_ntz_test.yml
+++ b/test_xdb/models/schema_tests/current_timestamp_ntz_test.yml
@@ -1,0 +1,12 @@
+version: 2
+
+models:
+    - name: current_timestamp_ntz_test
+      description: "tests that current_timestamp function return timestamp without timezones"
+      columns:
+          - name: result
+            tests:
+            - not_null
+            - accepted_values:
+                values: ['true']
+                quote: true

--- a/test_xdb/models/schema_tests/current_timestamp_test.yml
+++ b/test_xdb/models/schema_tests/current_timestamp_test.yml
@@ -1,0 +1,12 @@
+version: 2
+
+models:
+    - name: current_timestamp_test
+      description: "tests that current_timestamp function return timestamp with timezones"
+      columns:
+          - name: result
+            tests:
+            - not_null
+            - accepted_values:
+                values: ['true']
+                quote: true

--- a/test_xdb/models/schema_tests/like_any_test.yml
+++ b/test_xdb/models/schema_tests/like_any_test.yml
@@ -1,0 +1,12 @@
+version: 2
+
+models:
+    - name: like_any_test
+      description: "tests like any functionality"
+      columns:
+          - name: test_name
+            tests:
+            - not_null
+            - accepted_values:
+                values: ['test_1', 'test_2', 'test_11', 'test_22']
+                quote: true

--- a/test_xdb/models/schema_tests/schema.yml
+++ b/test_xdb/models/schema_tests/schema.yml
@@ -277,12 +277,3 @@ models:
               - accepted_values:
                    values: ['2019-12-31 23:00:00']
                    quote: true
-    - name: like_any_test
-      description: "do like any"
-      columns:
-        - name: test_name
-          tests:
-            - not_null
-            - accepted_values:
-                values: ['test_1', 'test_2', 'test_11', 'test_22']
-                quote: true

--- a/test_xdb/models/under_test/current_timestamp_ntz_test.sql
+++ b/test_xdb/models/under_test/current_timestamp_ntz_test.sql
@@ -1,0 +1,13 @@
+WITH timestamp_ntz AS (
+    {%- if target.type == 'postgres' -%}
+        SELECT PG_TYPEOF({{ xdb.current_timestamp_ntz() }})::varchar AS test_timestamp_without_timezone
+    {%- elif target.type == 'snowflake' -%}
+        SELECT TYPEOF(
+            TO_VARIANT({{ xdb.current_timestamp_ntz() }})
+        ) AS test_timestamp_without_timezone
+    {%- endif -%}
+)
+
+SELECT 'true' AS result
+FROM timestamp_ntz
+WHERE test_timestamp_without_timezone in ('TIMESTAMP_NTZ', 'timestamp without time zone')

--- a/test_xdb/models/under_test/current_timestamp_test.sql
+++ b/test_xdb/models/under_test/current_timestamp_test.sql
@@ -1,0 +1,13 @@
+WITH timestamp_tz AS (
+    {%- if target.type == 'postgres' -%}
+        SELECT PG_TYPEOF({{ xdb.current_timestamp() }})::varchar AS test_timestamp_with_timezone
+    {%- elif target.type == 'snowflake' -%}
+        SELECT TYPEOF(
+            TO_VARIANT({{ xdb.current_timestamp() }})
+        ) AS test_timestamp_with_timezone
+    {%- endif -%}
+)
+
+SELECT 'true' AS result
+FROM timestamp_tz
+WHERE test_timestamp_with_timezone in ('TIMESTAMP_LTZ', 'timestamp with time zone')


### PR DESCRIPTION
## What is this? 
Macroses for current_timestamp and current_timestamp_ntz for Snowflake and Posgtres systems

## What changes in this PR? 
Add 2 new macroses

## How does this impact our users?
Add more functionality

## PR Quality
- [+] does `docker-compose exec testxdb test` run successfully?
- [+] does `docker-compose exec testxdb docs` build docs without errors?
- [+] does `docker-compose exec testxdb coverage` pass coverage standards?
- [+] did you leave the codebase better than you found it? 




@Health-Union/hu-data make sure to include a version tag in the merge commit!