### PR TITLE
Generalising of implementation of clone_schema() macro.

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -222,11 +222,11 @@ converts `val` to the basic json type in the target database
 **xdb.clone_schema** (**schema_one** _string_, **schema_two** _string_, **comment_tag** _string_)
 
 /* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
-         If `comment_tag` argument is specified, it copies only TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
+         If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
 
 - schema_one : name of first schema.
 - schema_two : name of second schema.
-- comment_tag : value of `comment` metadata field that indicates object for copying. If it's not specified, all objects from `schema_one` will be copied to `schema_two`.
+- comment_tag : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
 
 **Returns**:         nothing to the call point.
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -4,6 +4,17 @@
 These macros carry functionality across **Snowflake** and **Postgresql**, and most also support **BigQuery**. Individual support listed below.
 
 
+### [_get_schema_grants_query](../macros/clone_schema_grants.sql)
+**xdb._get_schema_grants_query** (**schema_name** _None_)
+
+/*
+        This is an auxiliary macro for generating query which provides details
+        about applied grants on schema `schema_name` after being fetched.
+
+
+**Returns**: 
+##### Supports: _Snowflake_
+----
 ### [clone_schema_grants](../macros/clone_schema_grants.sql)
 **xdb.clone_schema_grants** (**schema_one** _string_, **schema_two** _string_)
 
@@ -210,11 +221,12 @@ converts `val` to the basic json type in the target database
 ### [clone_schema](../macros/clone_schema.sql)
 **xdb.clone_schema** (**schema_one** _string_, **schema_two** _string_, **comment_tag** _string_)
 
-/* Copies tables, views, sequences and functions from `schema_one` to `schema_two` if `comment_tag` isn't specified. If `comment_tag` argument is specified, it copies only tables and sequences that have `comment` metadata field equal to the passed value of `comment_tag` argument.
+/* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
+         If `comment_tag` argument is specified, it copies only TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
 
 - schema_one : name of first schema.
 - schema_two : name of second schema.
-- comment_tag : value of `comment` metadata field that indicates either table or sequence for copying. If it's not specified, all objects from `schema_one` will be copied to `schema_two`.
+- comment_tag : value of `comment` metadata field that indicates object for copying. If it's not specified, all objects from `schema_one` will be copied to `schema_two`.
 
 **Returns**:         nothing to the call point.
 
@@ -232,6 +244,27 @@ converts `val` to the basic json type in the target database
 **Returns**:      A string representing hash of given comments
 
 ##### Supports: _Postgres, Snowflake, BigQuery_
+----
+### [current_timestamp](../macros/current_timestamp.sql)
+**xdb.current_timestamp** (**timezone** _None_)
+
+/* Current timestamp function with time zone.
+
+- Optional timezone : timezone that should be applied for timestamp
+
+**Returns**:        Current system timestamp with default timezone or provided one
+
+##### Supports: _Postgres, Snowflake_
+----
+### [current_timestamp_ntz](../macros/current_timestamp_ntz.sql)
+**xdb.current_timestamp_ntz** (**** _None_)
+
+/* Current timestamp function without timezone info, UTC.
+
+
+**Returns**:        Current system timestamp without timezone, UTC.
+
+##### Supports: _Postgres, Snowflake_
 ----
 ### [date_part_day_of_week](../macros/date_part_day_of_week.sql)
 **xdb.date_part_day_of_week** (**val** _identifier/date/timestamp_)
@@ -419,7 +452,7 @@ converts `val` to the basic json type in the target database
 - patterns : patterns for like statement
 - escape : chars that will be used as an escape symbol for snowflake only!!
 
-**Returns**:        Varchars that mathed patterns.
+**Returns**:        Varchars that are matсhing provided patterns.
 
 ##### Supports: _Postgres, Snowflake_
 ----

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -1,11 +1,11 @@
 {%- macro clone_schema(schema_one, schema_two, comment_tag='') -%}
 
     {#/* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
-         If `comment_tag` argument is specified, it copies only TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
+         If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
        ARGS:
          - schema_one (string) : name of first schema.
          - schema_two (string) : name of second schema.
-         - comment_tag (string) : value of `comment` metadata field that indicates object for copying. If it's not specified, all objects from `schema_one` will be copied to `schema_two`.
+         - comment_tag (string) : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
        RETURNS: nothing to the call point.
        SUPPORTS:
             - Postgres

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -287,7 +287,6 @@
                                     , coalesce(comment, '-1') AS comment
                                 FROM information_schema.views
                                 WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
-                                    AND LOWER(comment) = LOWER('{{comment_tag}}')
                             )
                             , names AS (
                                 SELECT NAME AS view_name FROM views_data

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -305,45 +305,69 @@
         {%- else -%}
             {% set fetch_tagged_objects %}
                 USE SCHEMA {{schema_one}};
-                SELECT
-                    CASE WHEN is_transient = 'YES' THEN 'TRANSIENT TABLE' ELSE 'TABLE' END AS type
-                    , table_name AS name
-                    , NULL AS object_definition
-                    , coalesce(comment, '-1') AS comment
-                FROM information_schema.tables
-                WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
-                    AND LOWER(comment) = LOWER('{{comment_tag}}')
-                    AND table_type = 'BASE TABLE'
-                UNION ALL
-                SELECT
-                    'VIEW' AS type
-                    , table_name AS name
-                    , view_definition AS object_definition
-                    , coalesce(comment, '-1') AS comment
-                FROM information_schema.views
-                WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
-                    AND LOWER(comment) = LOWER('{{comment_tag}}')
-                UNION ALL
-                SELECT
-                    'SEQUENCE' AS type
-                    , sequence_name AS name
-                    , NULL AS object_definition
-                    , coalesce(comment, '-1') AS comment
-                FROM information_schema.sequences
-                WHERE LOWER(sequence_schema) = LOWER('{{schema_one}}')
-                    AND LOWER(comment) = LOWER('{{comment_tag}}')
-                {%- if functions_names is defined -%}
-                    {% for i in functions_names -%}
-                        {%- if i[1] == '{{comment_tag}}' -%}
-                UNION ALL
-                SELECT
-                    'FUNCTION' AS type
-                    , '{{i[0]}}' AS name
-                    , get_ddl('function', '{{i[0]}}') AS object_definition
-                    , '{{i[1]}}' AS comment
+                SELECT * FROM (
+                    SELECT
+                        CASE WHEN is_transient = 'YES' THEN 'TRANSIENT TABLE' ELSE 'TABLE' END AS type
+                        , table_name AS name
+                        , NULL AS object_definition
+                        , coalesce(comment, '-1') AS comment
+                        , 0 AS order_rank
+                    FROM information_schema.tables
+                    WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+                        AND LOWER(comment) = LOWER('{{comment_tag}}')
+                        AND table_type = 'BASE TABLE'
+                    UNION ALL
+                    SELECT * FROM (
+                        WITH views_data AS (
+                            SELECT
+                                'VIEW' AS type
+                                , table_name AS name
+                                , view_definition AS object_definition
+                                , coalesce(comment, '-1') AS comment
+                            FROM information_schema.views
+                            WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+                                AND LOWER(comment) = LOWER('{{comment_tag}}')
+                        )
+                        , names AS (
+                            SELECT NAME AS view_name FROM views_data
+                            )
+                        SELECT
+                            views_data.TYPE
+                            , views_data.NAME
+                            , views_data.object_definition
+                            , views_data.comment
+                            , SUM(CASE 
+                                    WHEN CONTAINS(lower(object_definition), lower(view_name))
+                                        AND VIEW_NAME <> NAME THEN 1
+                                    ELSE 0
+                                END) AS order_rank
+                        FROM views_data, names
+                        GROUP BY 1, 2, 3, 4
+                    ) views
+                    UNION ALL
+                    SELECT
+                        'SEQUENCE' AS type
+                        , sequence_name AS name
+                        , NULL AS object_definition
+                        , coalesce(comment, '-1') AS comment
+                        , 0 AS order_rank
+                    FROM information_schema.sequences
+                    WHERE LOWER(sequence_schema) = LOWER('{{schema_one}}')
+                        AND LOWER(comment) = LOWER('{{comment_tag}}')
+                    {%- if functions_names is defined -%}
+                        {% for i in functions_names -%}
+                            {%- if i[1] == '{{comment_tag}}' -%}
+                    UNION ALL
+                    SELECT                                                                                                                                                                                                                                                                                                                                                                             
+                        'FUNCTION' AS type
+                        , '{{i[0]}}' AS name
+                        , get_ddl('function', '{{i[0]}}') AS object_definition
+                        , '{{i[1]}}' AS comment
+                        , 0 AS order_rank
                         {%- endif -%}
                     {% endfor %}
                 {%- endif -%}
+                ) ORDER BY order_rank ASC;
             {% endset %}
         {%- endif -%}
 

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -248,7 +248,9 @@
 
     {%- elif target.type == 'snowflake' -%}
         {#/*
-            We don't use CLONE SCHEMA option here, because it leads to missing of DATABASE ROLE privileges on target schema after. Adding of COPY GRANTS syntax to single objects grant statements helps to avoid this effect.
+            We don't use CLONE SCHEMA option here, because this function doesn’t copy all grants for objects when used at the schema level.
+            Related extra information see here - https://docs.snowflake.com/en/user-guide/object-clone
+            Because of this effect we are applying a COPY GRANTS syntax to single objects grant statements which are generated in loop.
         */#}
 
         {#/*
@@ -260,12 +262,14 @@
                 , coalesce(comment, '-1') AS comment
             FROM information_schema.functions
             WHERE LOWER(function_schema) = LOWER('{{schema_one}}')
+        {% if comment_tag != '' -%}
+                    AND LOWER(comment) = LOWER('{{comment_tag}}')
+            {%- endif %}
         {% endset %}
 
         {% set functions_names = run_query(fetch_functions_names) %}
 
-        {%- if comment_tag == '' -%}
-            {% set fetch_tagged_objects %}
+        {% set fetch_tagged_objects %}
                 USE SCHEMA {{schema_one}};
                 SELECT * FROM (
                     SELECT
@@ -276,69 +280,9 @@
                         , 0 AS order_rank
                     FROM information_schema.tables
                     WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
-                        AND table_type = 'BASE TABLE'
-                    UNION ALL
-                    SELECT * FROM (
-                            WITH views_data AS (
-                                SELECT
-                                    'VIEW' AS type
-                                    , table_name AS name
-                                    , view_definition AS object_definition
-                                    , coalesce(comment, '-1') AS comment
-                                FROM information_schema.views
-                                WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
-                            )
-                            , names AS (
-                                SELECT NAME AS view_name FROM views_data
-                                )
-                            SELECT
-                                views_data.TYPE
-                                , views_data.NAME
-                                , views_data.object_definition
-                                , views_data.comment
-                                , SUM(CASE 
-                                        WHEN CONTAINS(lower(object_definition), lower(view_name))
-                                            AND VIEW_NAME <> NAME THEN 1
-                                        ELSE 0
-                                    END) AS order_rank
-                            FROM views_data, names
-                            GROUP BY 1, 2, 3, 4
-                        ) views
-                    UNION ALL
-                    SELECT
-                        'SEQUENCE' AS type
-                        , sequence_name AS name
-                        , NULL AS object_definition
-                        , coalesce(comment, '-1') AS comment
-                        , 0 AS order_rank
-                    FROM information_schema.sequences
-                    WHERE LOWER(sequence_schema) = LOWER('{{schema_one}}')
-                    {% if functions_names is defined -%}
-                        {% for i in functions_names -%}
-                    UNION ALL
-                    SELECT
-                        'FUNCTION' AS type
-                        , '{{i[0]}}' AS name
-                        , get_ddl('function', '{{i[0]}}') AS object_definition
-                        , '{{i[1]}}' AS comment
-                        , 0 AS order_rank
-                        {% endfor %}
-                    {%- endif -%}
-                ) ORDER BY order_rank ASC;
-            {% endset %}
-        {%- else -%}
-            {% set fetch_tagged_objects %}
-                USE SCHEMA {{schema_one}};
-                SELECT * FROM (
-                    SELECT
-                        CASE WHEN is_transient = 'YES' THEN 'TRANSIENT TABLE' ELSE 'TABLE' END AS type
-                        , table_name AS name
-                        , NULL AS object_definition
-                        , coalesce(comment, '-1') AS comment
-                        , 0 AS order_rank
-                    FROM information_schema.tables
-                    WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+        {% if comment_tag != '' -%}
                         AND LOWER(comment) = LOWER('{{comment_tag}}')
+        {%- endif %}
                         AND table_type = 'BASE TABLE'
                     UNION ALL
                     SELECT * FROM (
@@ -350,7 +294,9 @@
                                 , coalesce(comment, '-1') AS comment
                             FROM information_schema.views
                             WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+        {% if comment_tag != '' -%}
                                 AND LOWER(comment) = LOWER('{{comment_tag}}')
+        {%- endif %}
                         )
                         , names AS (
                             SELECT NAME AS view_name FROM views_data
@@ -377,10 +323,11 @@
                         , 0 AS order_rank
                     FROM information_schema.sequences
                     WHERE LOWER(sequence_schema) = LOWER('{{schema_one}}')
+        {% if comment_tag != '' -%}
                         AND LOWER(comment) = LOWER('{{comment_tag}}')
+        {%- endif %}
                     {%- if functions_names is defined -%}
                         {% for i in functions_names -%}
-                            {%- if i[1] == '{{comment_tag}}' -%}
                     UNION ALL
                     SELECT                                                                                                                                                                                                                                                                                                                                                                             
                         'FUNCTION' AS type
@@ -388,12 +335,10 @@
                         , get_ddl('function', '{{i[0]}}') AS object_definition
                         , '{{i[1]}}' AS comment
                         , 0 AS order_rank
-                        {%- endif -%}
-                    {% endfor %}
-                {%- endif -%}
+                            {% endfor %}
+                    {%- endif -%}
                 ) ORDER BY order_rank ASC;
-            {% endset %}
-        {%- endif -%}
+        {% endset %}
 
         {% set tagged_objects = run_query(fetch_tagged_objects) %}
 

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -1,18 +1,11 @@
 {%- macro clone_schema(schema_one, schema_two, comment_tag='') -%}
 
-    {#/* 
-        Postgres implementation:
-            - Copies tables, views, sequences and functions from `schema_one` to `schema_two` if `comment_tag` isn't specified.
-            - If `comment_tag` argument is specified, it copies only tables and sequences that have `comment` metadata field equal to the passed value of `comment_tag` argument.
-
-        Snowflake implementation:
-            - Copies tables and sequences from `schema_one` to `schema_two`.
-            - If `comment_tag` argument is specified, it copies only tables and sequences that have `comment` metadata field equal to the passed value of `comment_tag` argument.
-
+    {#/* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
+         If `comment_tag` argument is specified, it copies only TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
        ARGS:
          - schema_one (string) : name of first schema.
          - schema_two (string) : name of second schema.
-         - comment_tag (string) : value of `comment` metadata field that indicates either table or sequence for copying. If it's not specified, all objects from `schema_one` will be copied to `schema_two`.
+         - comment_tag (string) : value of `comment` metadata field that indicates object for copying. If it's not specified, all objects from `schema_one` will be copied to `schema_two`.
        RETURNS: nothing to the call point.
        SUPPORTS:
             - Postgres
@@ -23,7 +16,7 @@
     Note about `comment_tag` arg:
         Postgres DB doesn't support tags mechanism as Snowflake does so to make this macro more general metadata field `comment` is supposed to be used to filter objects needed to have in target schema. All of such objects have to be marked by a special comment.
     Example:
-        dbt run-operation clone_schema --args '{schema_one: prod, schema_two: stage, comment_tag: incremental}' --target ANALYSIS
+        dbt run-operation clone_schema --args '{schema_one: prod, schema_two: stage, comment_tag: incremental}' --target snowflake
     */#}
 
     {%- if target.type == 'postgres' -%}
@@ -257,37 +250,100 @@
         {#/*
             We don't use CLONE SCHEMA option here, because it leads to missing of DATABASE ROLE privileges on target schema after. Adding of COPY GRANTS syntax to single objects grant statements helps to avoid this effect.
         */#}
+
+        {#/*
+            The subsequent block fetches signatures of and comments on all functions in `schema_one`.
+        */#}
+        {% set fetch_functions_names %}
+            SELECT
+                function_name||regexp_replace(argument_signature,'\\w+\\s(\\w+)','\\1') AS full_function_name
+                , coalesce(comment, '-1') AS comment
+            FROM information_schema.functions
+            WHERE LOWER(function_schema) = LOWER('{{schema_one}}')
+        {% endset %}
+
+        {% set functions_names = run_query(fetch_functions_names) %}
+
         {%- if comment_tag == '' -%}
             {% set fetch_tagged_objects %}
+                USE SCHEMA {{schema_one}};
                 SELECT
                     CASE WHEN is_transient = 'YES' THEN 'TRANSIENT TABLE' ELSE 'TABLE' END AS type
                     , table_name AS name
+                    , NULL AS object_definition
+                    , coalesce(comment, '-1') AS comment
                 FROM information_schema.tables
                 WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
                     AND table_type = 'BASE TABLE'
                 UNION ALL
                 SELECT
+                    'VIEW' AS type
+                    , table_name AS name
+                    , view_definition AS object_definition
+                    , coalesce(comment, '-1') AS comment
+                FROM information_schema.views
+                WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+                UNION ALL
+                SELECT
                     'SEQUENCE' AS type
                     , sequence_name AS name
+                    , NULL AS object_definition
+                    , coalesce(comment, '-1') AS comment
                 FROM information_schema.sequences
                 WHERE LOWER(sequence_schema) = LOWER('{{schema_one}}')
+                {% if functions_names is defined -%}
+                    {% for i in functions_names -%}
+                UNION ALL
+                SELECT
+                    'FUNCTION' AS type
+                    , '{{i[0]}}' AS name
+                    , get_ddl('function', '{{i[0]}}') AS object_definition
+                    , '{{i[1]}}' AS comment
+                    {% endfor %}
+                {%- endif -%}
             {% endset %}
         {%- else -%}
             {% set fetch_tagged_objects %}
+                USE SCHEMA {{schema_one}};
                 SELECT
                     CASE WHEN is_transient = 'YES' THEN 'TRANSIENT TABLE' ELSE 'TABLE' END AS type
                     , table_name AS name
+                    , NULL AS object_definition
+                    , coalesce(comment, '-1') AS comment
                 FROM information_schema.tables
                 WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
                     AND LOWER(comment) = LOWER('{{comment_tag}}')
                     AND table_type = 'BASE TABLE'
                 UNION ALL
                 SELECT
+                    'VIEW' AS type
+                    , table_name AS name
+                    , view_definition AS object_definition
+                    , coalesce(comment, '-1') AS comment
+                FROM information_schema.views
+                WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+                    AND LOWER(comment) = LOWER('{{comment_tag}}')
+                UNION ALL
+                SELECT
                     'SEQUENCE' AS type
                     , sequence_name AS name
+                    , NULL AS object_definition
+                    , coalesce(comment, '-1') AS comment
                 FROM information_schema.sequences
                 WHERE LOWER(sequence_schema) = LOWER('{{schema_one}}')
                     AND LOWER(comment) = LOWER('{{comment_tag}}')
+                {%- if functions_names is defined -%}
+                    {% for i in functions_names -%}
+                        {%- if i[1] == '{{comment_tag}}' -%}
+                UNION ALL
+                SELECT
+                    'FUNCTION' AS type
+                    , '{{i[0]}}' AS name
+                    , get_ddl('function', '{{i[0]}}') AS object_definition
+                    , '{{i[1]}}' AS comment
+                        {%- endif -%}
+                    {% endfor %}
+                {%- endif -%}
             {% endset %}
         {%- endif -%}
 
@@ -296,10 +352,20 @@
         {% set sql %}
                 CREATE OR REPLACE SCHEMA {{schema_two}};
             {% for i in tagged_objects %}
-                {%- if i[0] == 'SEQUENCE' -%} 
+                {%- if i[0] == 'SEQUENCE' -%}
                     {{"CREATE " ~ i[0] ~ " " ~ schema_two ~ "." ~ i[1] ~ " CLONE " ~ schema_one ~ "." ~ i[1] ~ ";"}}
                 {%- else -%}
+                    {%- if i[0] == 'TABLE' or i[0] == 'TRANSIENT TABLE' -%}
                     {{"CREATE " ~ i[0] ~ " " ~ schema_two ~ "." ~ i[1] ~ " CLONE " ~ schema_one ~ "." ~ i[1] ~ " COPY GRANTS;"}}
+                    {%- else -%}
+                    {#/*
+                        This block provides DDLs for creation of functions and views.
+                    */#}
+                        {{i[2].replace(schema_one, schema_two)}}
+                        {%- if i[3] != '-1' -%}
+                    {{"COMMENT ON " ~ i[0] ~ " " ~ schema_two ~ "." ~ i[1] ~ " IS '" ~ i[3] ~ "';"}}
+                        {%- endif -%}
+                    {%- endif -%}
                 {%- endif -%}
             {% endfor %}
         {% endset %}

--- a/macros/swap_schema.sql
+++ b/macros/swap_schema.sql
@@ -28,6 +28,6 @@
 
     {% do run_query(sql) %}
 
-    {{ log("Schema's names were swapped successfully.", info=True) }}
+    {{ log("Schemas' names were swapped successfully.", info=True) }}
 
 {% endmacro %}

--- a/test_xdb/models/under_test/clone_schema_tables_data_equality_test.sql
+++ b/test_xdb/models/under_test/clone_schema_tables_data_equality_test.sql
@@ -42,25 +42,16 @@
     in test schemas were found after triggering of test runs of `clone_schema()` macro.
 */#}
 
-{%if target.type == 'snowflake' -%}
-    {% set test_tables = [('clone_schema_tables_data_two', 'table_1')
-                        , ('clone_schema_tables_data_two', 'table_2')
-                        , ('clone_schema_tables_data_three', 'table_2')
-                        , ('clone_schema_tables_data_four', 'table_1')
-                        , ('clone_schema_tables_data_four', 'table_2')
-                        , ('clone_schema_tables_data_five', 'table_2')] %}
-{% else %}
-    {% set test_tables = [('clone_schema_tables_data_two', 'table_1')
-                        , ('clone_schema_tables_data_two', 'table_2')
-                        , ('clone_schema_tables_data_two', 'view_1')
-                        , ('clone_schema_tables_data_two', 'view_2') 
-                        , ('clone_schema_tables_data_three', 'table_2')
-                        , ('clone_schema_tables_data_four', 'table_1')
-                        , ('clone_schema_tables_data_four', 'table_2')
-                        , ('clone_schema_tables_data_four', 'view_1')
-                        , ('clone_schema_tables_data_four', 'view_2') 
-                        , ('clone_schema_tables_data_five', 'table_2')] %}
-{% endif %}
+{% set test_tables = [('clone_schema_tables_data_two', 'table_1')
+                      , ('clone_schema_tables_data_two', 'table_2')
+                      , ('clone_schema_tables_data_two', 'view_1')
+                      , ('clone_schema_tables_data_two', 'view_2') 
+                      , ('clone_schema_tables_data_three', 'table_2')
+                      , ('clone_schema_tables_data_four', 'table_1')
+                      , ('clone_schema_tables_data_four', 'table_2')
+                      , ('clone_schema_tables_data_four', 'view_1')
+                      , ('clone_schema_tables_data_four', 'view_2') 
+                      , ('clone_schema_tables_data_five', 'table_2')] %}
 
 WITH all_tables_counts AS (
     {% for i in test_tables -%}

--- a/test_xdb/models/under_test/clone_schema_test.sql
+++ b/test_xdb/models/under_test/clone_schema_test.sql
@@ -261,5 +261,4 @@ WITH all_objects_metadata AS (
 SELECT *
 FROM final_stats
 {%if target.type == 'snowflake' -%}
-WHERE object_type NOT IN ('view', 'function')
 {% endif %}


### PR DESCRIPTION
## What is this? 
_This PR makes behaviour of `clone_schema` macro more consistent across Postgres and Snowflake implementations._

## What changes in this PR? 
_Now `clone_schema` macro copies views and functions respecting to `comment_tag` argument's input in both implementations._

## How does this impact our users?
_This update makes behaviour of `clone_schema` macro more general and consistent. This update also allows us to use it safely without `comment_tag` with `PROD` and `STAGE` schemas.
Examples of the new version's successful applying:_
_1. w `comment_tag` flag - https://cloud.getdbt.com/deploy/159/projects/3671/runs/236891093_
_2. w/o `comment_tag` flag - https://cloud.getdbt.com/deploy/159/projects/3671/runs/236891174_

## PR Quality
- [ + ] does `docker-compose exec testxdb test` run successfully?
- [ + ] does `docker-compose exec testxdb docs` build docs without errors?
- [ + ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ + ] did you leave the codebase better than you found it? (I hope so :-))

@Health-Union/hu-data make sure to include a version tag in the merge commit!