### PR TITLE
feature/data 7285 Updates of the clone_schema() macro.

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -224,9 +224,9 @@ converts `val` to the basic json type in the target database
 /* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
          If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
 
-- schema_one : name of first schema, case-insensitive, for Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'.
-- schema_two : name of second schema, case-insensitive, for Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'.
-- comment_tag : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying, case-insensitive. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
+- schema_one : name of first schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'. Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name at the same time.
+- schema_two : name of second schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'. Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name at the same time.
+- comment_tag : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying, case-insensitive, optional. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
 
 **Returns**:         nothing to the call point.
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -223,9 +223,10 @@ converts `val` to the basic json type in the target database
 
 /* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
          If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
+         Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name.
 
-- schema_one : name of first schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'. Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name at the same time.
-- schema_two : name of second schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'. Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name at the same time.
+- schema_one : name of first schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'.
+- schema_two : name of second schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'.
 - comment_tag : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying, case-insensitive, optional. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
 
 **Returns**:         nothing to the call point.

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -223,7 +223,7 @@ converts `val` to the basic json type in the target database
 
 /* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
          If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
-         Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name.
+         Note (!) that for Snowflake DB `schema_one` and `schema_two` values must stick the same format - the both should either have or not have a database name.
 
 - schema_one : name of first schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'.
 - schema_two : name of second schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'.

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -224,9 +224,9 @@ converts `val` to the basic json type in the target database
 /* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
          If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
 
-- schema_one : name of first schema.
-- schema_two : name of second schema.
-- comment_tag : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
+- schema_one : name of first schema, case-insensitive, for Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'.
+- schema_two : name of second schema, case-insensitive, for Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'.
+- comment_tag : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying, case-insensitive. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
 
 **Returns**:         nothing to the call point.
 

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -354,7 +354,7 @@
                     {#/*
                         This block provides DDLs for creation of functions and views.
                     */#}
-                        {{i[2].replace(schema_one, schema_two)}}
+                        {{i[2].replace(schema_one, schema_two) ~ ";"}}
                         {%- if i[3] != '-1' -%}
                     {{"COMMENT ON " ~ i[0] ~ " " ~ schema_two ~ "." ~ i[1] ~ " IS '" ~ i[3] ~ "';"}}
                         {%- endif -%}

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -42,7 +42,7 @@
     {%- if target.type == 'postgres' -%}
 
         {#/*
-            This block of code is intended to catching of not correct values for the schemas' names.
+            This block of code is intended to catch invalid values for the schemas' names.
         */#}
         {% if schema_one_database != '-1' or schema_two_database != '-1' -%}
             {{ exceptions.raise_compiler_error('The `schema_one` and `schema_two` must not include a database name for the Postgres DB adapter.') }}

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -256,12 +256,22 @@
         {#/*
             The subsequent block fetches signatures of and comments on all functions in `schema_one`.
         */#}
+        {% set schema_one_short_name = schema_one %}
+        {% if schema_one.split('.') | length == 2 -%}
+            {% set schema_one_short_name = schema_one.split('.')[1] %}
+        {%- endif %}
+
+        {% set schema_two_short_name = schema_two %}
+        {% if schema_two.split('.') | length == 2 -%}
+            {% set schema_two_short_name = schema_two.split('.')[1] %}
+        {%- endif %}
+
         {% set fetch_functions_names %}
             SELECT
                 function_name||regexp_replace(argument_signature,'\\w+\\s(\\w+)','\\1') AS full_function_name
                 , coalesce(comment, '-1') AS comment
             FROM information_schema.functions
-            WHERE LOWER(function_schema) = LOWER('{{schema_one}}')
+            WHERE LOWER(function_schema) = LOWER('{{schema_one_short_name}}')
         {% if comment_tag != '' -%}
                     AND LOWER(comment) = LOWER('{{comment_tag}}')
             {%- endif %}
@@ -279,7 +289,7 @@
                         , coalesce(comment, '-1') AS comment
                         , 0 AS order_rank
                     FROM information_schema.tables
-                    WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+                    WHERE LOWER(table_schema) = LOWER('{{schema_one_short_name}}')
         {% if comment_tag != '' -%}
                         AND LOWER(comment) = LOWER('{{comment_tag}}')
         {%- endif %}
@@ -293,7 +303,7 @@
                                 , view_definition AS object_definition
                                 , coalesce(comment, '-1') AS comment
                             FROM information_schema.views
-                            WHERE LOWER(table_schema) = LOWER('{{schema_one}}')
+                            WHERE LOWER(table_schema) = LOWER('{{schema_one_short_name}}')
         {% if comment_tag != '' -%}
                                 AND LOWER(comment) = LOWER('{{comment_tag}}')
         {%- endif %}
@@ -322,7 +332,7 @@
                         , coalesce(comment, '-1') AS comment
                         , 0 AS order_rank
                     FROM information_schema.sequences
-                    WHERE LOWER(sequence_schema) = LOWER('{{schema_one}}')
+                    WHERE LOWER(sequence_schema) = LOWER('{{schema_one_short_name}}')
         {% if comment_tag != '' -%}
                         AND LOWER(comment) = LOWER('{{comment_tag}}')
         {%- endif %}
@@ -354,7 +364,12 @@
                     {#/*
                         This block provides DDLs for creation of functions and views.
                     */#}
-                        {{i[2].replace(schema_one, schema_two) ~ ";"}}
+                        {% set view_query = i[2].replace(schema_one, schema_two) %}
+                        {%- if view_query[-1] != ';'-%}
+                            {{ view_query ~ ";" }}
+                        {%- else -%}
+                            {{ view_query }}
+                        {%- endif -%}
                         {%- if i[3] != '-1' -%}
                     {{"COMMENT ON " ~ i[0] ~ " " ~ schema_two ~ "." ~ i[1] ~ " IS '" ~ i[3] ~ "';"}}
                         {%- endif -%}

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -2,9 +2,10 @@
 
     {#/* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
          If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
+         Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name.
        ARGS:
-         - schema_one (string) : name of first schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'. Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name at the same time.
-         - schema_two (string) : name of second schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'. Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name at the same time.
+         - schema_one (string) : name of first schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'.
+         - schema_two (string) : name of second schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'.
          - comment_tag (string) : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying, case-insensitive, optional. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
        RETURNS: nothing to the call point.
        SUPPORTS:

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -282,7 +282,7 @@
         */#}
 
         {#/*
-            This block of code is intended to catching of not correct values for the schemas' names.
+            This block of code is intended to catch invalid values for the schemas' names.
         */#}
         {% if (schema_one_database == '-1' and schema_two_database != '-1') 
             or (schema_one_database != '-1' and schema_two_database == '-1') -%}
@@ -394,11 +394,7 @@
                         This block provides DDLs for creation of functions and views.
                     */#}
                         {% set view_query = i[2].replace(schema_one ~ '.', schema_two ~ '.') %}
-                        {%- if view_query[-1] != ';'-%}
-                            {{ view_query ~ ";" }}
-                        {%- else -%}
-                            {{ view_query }}
-                        {%- endif -%}
+                        {{ view_query }}
                         {%- if i[3] != '-1' -%}
                     {{"COMMENT ON " ~ i[0] ~ " " ~ schema_two ~ "." ~ i[1] ~ " IS '" ~ i[3] ~ "';"}}
                         {%- endif -%}

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -2,7 +2,7 @@
 
     {#/* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
          If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
-         Note (!) that for Snowflake DB `schema_one` and `schema_one` values must stick the same format - the both should either have or not have a database name.
+         Note (!) that for Snowflake DB `schema_one` and `schema_two` values must stick the same format - the both should either have or not have a database name.
        ARGS:
          - schema_one (string) : name of first schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'.
          - schema_two (string) : name of second schema, case-insensitive, mandatory. For Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'.
@@ -287,7 +287,7 @@
         */#}
         {% if (schema_one_database == '-1' and schema_two_database != '-1') 
             or (schema_one_database != '-1' and schema_two_database == '-1') -%}
-            {{ exceptions.raise_compiler_error('The both of the `schema_one` and `schema_two` schemas must either have or not have a database name at the same time.') }}
+            {{ exceptions.raise_compiler_error('The both of the `schema_one` and `schema_two` schemas must either have or not have a database name.') }}
         {%- elif (schema_one_short_name == schema_two_short_name) and (schema_one_database == schema_two_database) -%}
             {{ exceptions.raise_compiler_error('The `schema_one` and `schema_two` must be a different schemas!') }}
         {%- endif %}

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -3,9 +3,9 @@
     {#/* If `comment_tag` isn't specified, it copies all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` to `schema_two`.
          If `comment_tag` argument is specified, it copies TABLES, VIEWS, SEQUENCES and FUNCTIONS that have `comment` metadata field equal to the passed value of `comment_tag` argument.
        ARGS:
-         - schema_one (string) : name of first schema.
-         - schema_two (string) : name of second schema.
-         - comment_tag (string) : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
+         - schema_one (string) : name of first schema, case-insensitive, for Snowflake DB it also could include a database name. Examples: Postgres - 'PROD', Snowflake - 'PROD' or 'DATA_WAREHOUSE.PROD'.
+         - schema_two (string) : name of second schema, case-insensitive, for Snowflake DB it also could include a database name. Examples: Postgres - 'STAGE', Snowflake - 'STAGE' or 'DATA_WAREHOUSE.STAGE'.
+         - comment_tag (string) : value of `comment` metadata field that indicates TABLE, VIEW, SEQUENCE or FUNCTION for copying, case-insensitive. If it's not specified, all TABLES, VIEWS, SEQUENCES and FUNCTIONS from `schema_one` will be copied to `schema_two`.
        RETURNS: nothing to the call point.
        SUPPORTS:
             - Postgres
@@ -14,7 +14,8 @@
 
     {#/*
     Note about `comment_tag` arg:
-        Postgres DB doesn't support tags mechanism as Snowflake does so to make this macro more general metadata field `comment` is supposed to be used to filter objects needed to have in target schema. All of such objects have to be marked by a special comment.
+        Postgres DB doesn't support tags mechanism as Snowflake does so to make this macro more general metadata field `comment` is supposed to be used to filter objects needed to have in target schema.
+        All of such objects have to be marked by a special comment.
     Example:
         dbt run-operation clone_schema --args '{schema_one: prod, schema_two: stage, comment_tag: incremental}' --target snowflake
     */#}
@@ -364,7 +365,7 @@
                     {#/*
                         This block provides DDLs for creation of functions and views.
                     */#}
-                        {% set view_query = i[2].replace(schema_one, schema_two) %}
+                        {% set view_query = i[2].replace(schema_one ~ '.', schema_two ~ '.') %}
                         {%- if view_query[-1] != ';'-%}
                             {{ view_query ~ ";" }}
                         {%- else -%}

--- a/test_xdb/scripts/test_run.py
+++ b/test_xdb/scripts/test_run.py
@@ -61,7 +61,7 @@ for target in targets:
                                                       b'The `schema_one` and `schema_two` must be a different schemas!')]))
         if target == 'snowflake':
             passed = bool(sum([val in out for val in (b'Compilation Error', 
-                                                      b'The both of the `schema_one` and `schema_two` schemas must either have or not have a database name at the same time.',
+                                                      b'The both of the `schema_one` and `schema_two` schemas must either have or not have a database name.',
                                                       b'The `schema_one` and `schema_two` must be a different schemas!')]))
 
         print("\033[0;32mAnticipated compilation error by clone_schema() macro for {0} arguments list is correctly thrown, exceptions pass.\033[0m".format(args_case) 

--- a/test_xdb/scripts/test_run.py
+++ b/test_xdb/scripts/test_run.py
@@ -54,8 +54,7 @@ for target in targets:
                                                     stderr=subprocess.PIPE)
         print(exceptions_clone_schema)
         out, _ = exceptions_clone_schema.communicate()
-        #print(out)
-        #print(_)
+
         if target == 'postgres':
             passed = bool(sum([val in out for val in (b'Compilation Error', 
                                                       b'The `schema_one` and `schema_two` must not include a database name for the Postgres DB adapter.',

--- a/test_xdb/scripts/test_run.py
+++ b/test_xdb/scripts/test_run.py
@@ -34,6 +34,23 @@ for target in targets:
     
     print("\033[0;32mAnticipated error(s) correctly thrown, exceptions pass.\033[0m" if passed else "\033[0;31mExpected error not thrown!\033[0m") 
     success += int(not passed)
+
+    ## test that clone_schema() macro throws a compilation errors
+    exceptions_clone_schema = subprocess.Popen(['dbt','run-operation','clone_schema',
+                                                '--args "{schema_one: XDB_TEST.STAGE, schema_two: XDB_TEST.STAGE}"',
+                                                '--profiles-dir','.',
+                                                '--target', target], 
+                                                stdout=subprocess.PIPE, 
+                                                stderr=subprocess.PIPE)
+    out, _ = exceptions_text.communicate()
+    if target == 'postgres':
+        passed = bool(sum([val in out for val in (b'Compilation Error', b'The `schema_one` and `schema_two` must not include a database name for the Postgres DB adapter.',)]))
+    if target == 'snowflake':
+        passed = bool(sum([val in out for val in (b'Compilation Error', b'The `schema_one` and `schema_two` must be a different schemas!',)]))
+
+    print("\033[0;32mAnticipated error by clone_schema() macro correctly thrown, exceptions pass.\033[0m" if passed else "\033[0;31mExpected error clone_schema() macro is not thrown!\033[0m") 
+    success += int(not passed)
+
     if success != 0:
         failed_targets.append(target)
 

--- a/test_xdb/scripts/test_run.py
+++ b/test_xdb/scripts/test_run.py
@@ -67,7 +67,7 @@ for target in targets:
 
         print("\033[0;32mAnticipated compilation error by clone_schema() macro for {0} arguments list is correctly thrown, exceptions pass.\033[0m".format(args_case) 
             if passed 
-            else "\033[0;31mExpected error clone_schema() macro is not thrown!\033[0m") 
+            else "\033[0;31mExpected compilation error clone_schema() macro for {0} arguments list is not thrown!\033[0m") 
         success += int(not passed)
 
         if success != 0:

--- a/test_xdb/scripts/test_run.py
+++ b/test_xdb/scripts/test_run.py
@@ -35,21 +35,43 @@ for target in targets:
     print("\033[0;32mAnticipated error(s) correctly thrown, exceptions pass.\033[0m" if passed else "\033[0;31mExpected error not thrown!\033[0m") 
     success += int(not passed)
 
-    ## test that clone_schema() macro throws a compilation errors
-    exceptions_clone_schema = subprocess.Popen(['dbt','run-operation','clone_schema',
-                                                '--args "{schema_one: XDB_TEST.STAGE, schema_two: XDB_TEST.STAGE}"',
-                                                '--profiles-dir','.',
-                                                '--target', target], 
-                                                stdout=subprocess.PIPE, 
-                                                stderr=subprocess.PIPE)
-    out, _ = exceptions_text.communicate()
-    if target == 'postgres':
-        passed = bool(sum([val in out for val in (b'Compilation Error', b'The `schema_one` and `schema_two` must not include a database name for the Postgres DB adapter.',)]))
-    if target == 'snowflake':
-        passed = bool(sum([val in out for val in (b'Compilation Error', b'The `schema_one` and `schema_two` must be a different schemas!',)]))
+    ## test that clone_schema() macro throws an anticipated compilation errors for different inputs
+    args_cases_list = ['{schema_one: xdb_test.some_test_schema_name, schema_two: xdb_test.some_test_schema_name}',
+                       '{schema_one: xdb_test.some_test_schema_name, schema_two: xdb_test.some_test_schema_name, comment_tag: some_tag}',
+                       '{schema_one: some_test_schema_name, schema_two: some_test_schema_name}',
+                       '{schema_one: some_test_schema_name, schema_two: some_test_schema_name, comment_tag: some_tag}',
+                       '{schema_one: xdb_test.some_test_schema_name, schema_two: some_test_schema_name}',
+                       '{schema_one: xdb_test.some_test_schema_name, schema_two: some_test_schema_name, comment_tag: some_tag}',
+                       '{schema_one: some_test_schema_name, schema_two: xdb_test.some_test_schema_name}',
+                       '{schema_one: some_test_schema_name, schema_two: xdb_test.some_test_schema_name, comment_tag: some_tag}']
 
-    print("\033[0;32mAnticipated error by clone_schema() macro correctly thrown, exceptions pass.\033[0m" if passed else "\033[0;31mExpected error clone_schema() macro is not thrown!\033[0m") 
-    success += int(not passed)
+    for args_case in args_cases_list:
+        exceptions_clone_schema = subprocess.Popen(['dbt','run-operation','clone_schema',
+                                                    '--profiles-dir','.',
+                                                    '--target', target,
+                                                    '--args', args_case], 
+                                                    stdout=subprocess.PIPE, 
+                                                    stderr=subprocess.PIPE)
+        print(exceptions_clone_schema)
+        out, _ = exceptions_clone_schema.communicate()
+        #print(out)
+        #print(_)
+        if target == 'postgres':
+            passed = bool(sum([val in out for val in (b'Compilation Error', 
+                                                      b'The `schema_one` and `schema_two` must not include a database name for the Postgres DB adapter.',
+                                                      b'The `schema_one` and `schema_two` must be a different schemas!')]))
+        if target == 'snowflake':
+            passed = bool(sum([val in out for val in (b'Compilation Error', 
+                                                      b'The both of the `schema_one` and `schema_two` schemas must either have or not have a database name at the same time.',
+                                                      b'The `schema_one` and `schema_two` must be a different schemas!')]))
+
+        print("\033[0;32mAnticipated compilation error by clone_schema() macro for {0} arguments list is correctly thrown, exceptions pass.\033[0m".format(args_case) 
+            if passed 
+            else "\033[0;31mExpected error clone_schema() macro is not thrown!\033[0m") 
+        success += int(not passed)
+
+        if success != 0:
+            failed_targets.append(target)
 
     if success != 0:
         failed_targets.append(target)


### PR DESCRIPTION
## What is this? 
* _This PR makes clone_schema() macro copy views across the schemas correctly._
* _This PR makes clone_schema() macro handle a schema names with database names as an arguments (for Snowflake DB)._
* _This PR makes clone_schema() macro safer in some use cases._

## What changes in this PR? 
* _It contains a clone_schema() macro code changes._
* _It enables an additional tests for a clone_schema() macro calls in the pipeline._

## How does this impact our users?
* _It could allow users to use this functionality correctly without `comment_tag` argument passing._
* _It could make using to this functionality a bit safer from the data keeping perspective._

## PR Quality
- [ + ] does `docker-compose exec testxdb test` run successfully?
- [ + ] does `docker-compose exec testxdb docs` build docs without errors?
- [ + ] does `docker-compose exec testxdb coverage` pass coverage standards?
- [ + ] did you leave the codebase better than you found it? (hope so!)

@Health-Union/hu-data make sure to include a version tag in the merge commit!